### PR TITLE
chore: note main branch protection in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,11 @@ git pull origin main
 - ALWAYS use `Closes #<N>` in the PR body to auto-close the GitHub issue
 - ALWAYS delete the branch after merge (`--delete-branch`)
 
+> ⚠️ **BRANCH PROTECTION — `main` is a protected branch:**
+> - `git push origin main` will be **rejected**
+> - ALL changes to `main` MUST go through a PR — no exceptions
+> - This applies to every commit, including chores, fixes, and docs updates
+
 ### Running Locally
 
 ```bash


### PR DESCRIPTION
Documents that `main` is a protected branch — direct pushes are rejected, all changes must go through a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)