### PR TITLE
feat: User aggregate — entity, status enum, repository

### DIFF
--- a/src/main/kotlin/com/aibles/iam/identity/domain/user/User.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/domain/user/User.kt
@@ -1,0 +1,66 @@
+package com.aibles.iam.identity.domain.user
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "users")
+class User private constructor(
+    @Id val id: UUID = UUID.randomUUID(),
+    @Column(unique = true, nullable = false) val email: String,
+    var displayName: String? = null,
+    @Column(unique = true) val googleSub: String? = null,
+    @Enumerated(EnumType.STRING) var status: UserStatus = UserStatus.ACTIVE,
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = [JoinColumn(name = "user_id")])
+    @Column(name = "role") var roles: MutableSet<String> = mutableSetOf("USER"),
+    val createdAt: Instant = Instant.now(),
+    var updatedAt: Instant = Instant.now(),
+    var lastLoginAt: Instant? = null,
+) {
+    // Required by JPA
+    protected constructor() : this(email = "")
+
+    companion object {
+        fun create(email: String, displayName: String? = null, googleSub: String? = null): User {
+            require(email.isNotBlank() && email.contains("@")) { "Invalid email: $email" }
+            return User(
+                email = email.lowercase().trim(),
+                displayName = displayName?.trim(),
+                googleSub = googleSub,
+            )
+        }
+    }
+
+    fun updateProfile(newDisplayName: String) {
+        displayName = newDisplayName.trim()
+        updatedAt = Instant.now()
+    }
+
+    fun disable() {
+        status = UserStatus.DISABLED
+        updatedAt = Instant.now()
+    }
+
+    fun enable() {
+        status = UserStatus.ACTIVE
+        updatedAt = Instant.now()
+    }
+
+    fun recordLogin() {
+        lastLoginAt = Instant.now()
+        updatedAt = Instant.now()
+    }
+
+    fun isActive() = status == UserStatus.ACTIVE
+}

--- a/src/main/kotlin/com/aibles/iam/identity/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/domain/user/UserRepository.kt
@@ -1,0 +1,13 @@
+package com.aibles.iam.identity.domain.user
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface UserRepository : JpaRepository<User, UUID> {
+    fun existsByEmail(email: String): Boolean
+    fun findByEmail(email: String): User?
+    fun findByGoogleSub(googleSub: String): User?
+    override fun findAll(pageable: Pageable): Page<User>
+}

--- a/src/main/kotlin/com/aibles/iam/identity/domain/user/UserStatus.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/domain/user/UserStatus.kt
@@ -1,0 +1,6 @@
+package com.aibles.iam.identity.domain.user
+
+enum class UserStatus {
+    ACTIVE,
+    DISABLED,
+}

--- a/src/test/kotlin/com/aibles/iam/identity/domain/user/UserTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/domain/user/UserTest.kt
@@ -1,0 +1,45 @@
+package com.aibles.iam.identity.domain.user
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UserTest {
+
+    @Test
+    fun `create lowercases and trims email`() =
+        assertThat(User.create("  TEST@EXAMPLE.COM  ").email).isEqualTo("test@example.com")
+
+    @Test
+    fun `create rejects blank email`() =
+        assertThrows<IllegalArgumentException> { User.create("") }
+
+    @Test
+    fun `create rejects email without at sign`() =
+        assertThrows<IllegalArgumentException> { User.create("notanemail") }
+
+    @Test
+    fun `disable sets DISABLED status`() {
+        val user = User.create("a@b.com").also { it.disable() }
+        assertThat(user.isActive()).isFalse()
+        assertThat(user.status).isEqualTo(UserStatus.DISABLED)
+    }
+
+    @Test
+    fun `enable restores ACTIVE after disable`() {
+        val user = User.create("a@b.com").also { it.disable(); it.enable() }
+        assertThat(user.isActive()).isTrue()
+    }
+
+    @Test
+    fun `updateProfile trims display name`() {
+        val user = User.create("a@b.com").also { it.updateProfile("  Alice  ") }
+        assertThat(user.displayName).isEqualTo("Alice")
+    }
+
+    @Test
+    fun `recordLogin sets lastLoginAt`() {
+        val user = User.create("a@b.com").also { it.recordLogin() }
+        assertThat(user.lastLoginAt).isNotNull()
+    }
+}


### PR DESCRIPTION
## Summary
- `User.kt` — `@Entity` with private constructor, `create()` factory enforcing email validation (blank/missing-@ rejected), lowercase+trim normalization, domain methods: `updateProfile`, `disable`, `enable`, `recordLogin`, `isActive`
- `UserStatus.kt` — `ACTIVE` / `DISABLED` enum
- `UserRepository.kt` — `JpaRepository` + `existsByEmail`, `findByEmail`, `findByGoogleSub`

## Test Plan
- [x] `UserTest` — 7 TDD tests, all passing (`./gradlew test --tests "com.aibles.iam.identity.domain.user.*"` → BUILD SUCCESSFUL)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)