### PR TITLE
feat: User CRUD use cases

### DIFF
--- a/src/main/kotlin/com/aibles/iam/identity/usecase/ChangeUserStatusUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/usecase/ChangeUserStatusUseCase.kt
@@ -1,0 +1,26 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.identity.domain.user.UserStatus
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ChangeUserStatusUseCase(private val userRepository: UserRepository) {
+
+    data class Command(val id: UUID, val status: UserStatus)
+    data class Result(val user: User)
+
+    fun execute(command: Command): Result {
+        val user = userRepository.findById(command.id)
+            .orElseThrow { NotFoundException("User not found: ${command.id}", ErrorCode.USER_NOT_FOUND) }
+        when (command.status) {
+            UserStatus.ACTIVE -> user.enable()
+            UserStatus.DISABLED -> user.disable()
+        }
+        return Result(userRepository.save(user))
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/identity/usecase/CreateUserUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/usecase/CreateUserUseCase.kt
@@ -1,0 +1,21 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ConflictException
+import com.aibles.iam.shared.error.ErrorCode
+import org.springframework.stereotype.Component
+
+@Component
+class CreateUserUseCase(private val userRepository: UserRepository) {
+
+    data class Command(val email: String, val displayName: String?, val googleSub: String?)
+    data class Result(val user: User)
+
+    fun execute(command: Command): Result {
+        if (userRepository.existsByEmail(command.email.lowercase().trim()))
+            throw ConflictException("Email already registered", ErrorCode.USER_EMAIL_CONFLICT)
+        val user = User.create(command.email, command.displayName, command.googleSub)
+        return Result(userRepository.save(user))
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/identity/usecase/DeleteUserUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/usecase/DeleteUserUseCase.kt
@@ -1,0 +1,19 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class DeleteUserUseCase(private val userRepository: UserRepository) {
+
+    data class Command(val id: UUID)
+
+    fun execute(command: Command) {
+        val user = userRepository.findById(command.id)
+            .orElseThrow { NotFoundException("User not found: ${command.id}", ErrorCode.USER_NOT_FOUND) }
+        userRepository.delete(user)
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/identity/usecase/GetUserUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/usecase/GetUserUseCase.kt
@@ -1,0 +1,18 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class GetUserUseCase(private val userRepository: UserRepository) {
+
+    data class Query(val id: UUID)
+
+    fun execute(query: Query): User =
+        userRepository.findById(query.id)
+            .orElseThrow { NotFoundException("User not found: ${query.id}", ErrorCode.USER_NOT_FOUND) }
+}

--- a/src/main/kotlin/com/aibles/iam/identity/usecase/UpdateUserUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/usecase/UpdateUserUseCase.kt
@@ -1,0 +1,22 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UpdateUserUseCase(private val userRepository: UserRepository) {
+
+    data class Command(val id: UUID, val displayName: String)
+    data class Result(val user: User)
+
+    fun execute(command: Command): Result {
+        val user = userRepository.findById(command.id)
+            .orElseThrow { NotFoundException("User not found: ${command.id}", ErrorCode.USER_NOT_FOUND) }
+        user.updateProfile(command.displayName)
+        return Result(userRepository.save(user))
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/usecase/ChangeUserStatusUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.identity.domain.user.UserStatus
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Optional
+import java.util.UUID
+
+class ChangeUserStatusUseCaseTest {
+    private val repo = mockk<UserRepository>()
+    private val useCase = ChangeUserStatusUseCase(repo)
+
+    @Test
+    fun `disables an active user`() {
+        val user = User.create("a@b.com")
+        every { repo.findById(user.id) } returns Optional.of(user)
+        every { repo.save(any()) } answers { firstArg() }
+
+        val result = useCase.execute(ChangeUserStatusUseCase.Command(user.id, UserStatus.DISABLED))
+
+        assertThat(result.user.isActive()).isFalse()
+        verify(exactly = 1) { repo.save(user) }
+    }
+
+    @Test
+    fun `enables a disabled user`() {
+        val user = User.create("a@b.com").also { it.disable() }
+        every { repo.findById(user.id) } returns Optional.of(user)
+        every { repo.save(any()) } answers { firstArg() }
+
+        val result = useCase.execute(ChangeUserStatusUseCase.Command(user.id, UserStatus.ACTIVE))
+
+        assertThat(result.user.isActive()).isTrue()
+    }
+
+    @Test
+    fun `throws NotFoundException when user not found`() {
+        val id = UUID.randomUUID()
+        every { repo.findById(id) } returns Optional.empty()
+
+        val ex = assertThrows<NotFoundException> {
+            useCase.execute(ChangeUserStatusUseCase.Command(id, UserStatus.DISABLED))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_NOT_FOUND)
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/usecase/CreateUserUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/usecase/CreateUserUseCaseTest.kt
@@ -1,0 +1,40 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ConflictException
+import com.aibles.iam.shared.error.ErrorCode
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CreateUserUseCaseTest {
+    private val repo = mockk<UserRepository>()
+    private val useCase = CreateUserUseCase(repo)
+
+    @Test
+    fun `creates and saves user`() {
+        every { repo.existsByEmail("a@b.com") } returns false
+        every { repo.save(any()) } answers { firstArg() }
+
+        val result = useCase.execute(CreateUserUseCase.Command("a@b.com", "Alice", null))
+
+        assertThat(result.user.email).isEqualTo("a@b.com")
+        assertThat(result.user.displayName).isEqualTo("Alice")
+        verify(exactly = 1) { repo.save(any()) }
+    }
+
+    @Test
+    fun `throws ConflictException for duplicate email`() {
+        every { repo.existsByEmail(any()) } returns true
+
+        val ex = assertThrows<ConflictException> {
+            useCase.execute(CreateUserUseCase.Command("a@b.com", null, null))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_EMAIL_CONFLICT)
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/usecase/DeleteUserUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/usecase/DeleteUserUseCaseTest.kt
@@ -1,0 +1,42 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Optional
+import java.util.UUID
+
+class DeleteUserUseCaseTest {
+    private val repo = mockk<UserRepository>()
+    private val useCase = DeleteUserUseCase(repo)
+
+    @Test
+    fun `deletes existing user`() {
+        val user = User.create("a@b.com")
+        every { repo.findById(user.id) } returns Optional.of(user)
+        justRun { repo.delete(user) }
+
+        useCase.execute(DeleteUserUseCase.Command(user.id))
+
+        verify(exactly = 1) { repo.delete(user) }
+    }
+
+    @Test
+    fun `throws NotFoundException when user not found`() {
+        val id = UUID.randomUUID()
+        every { repo.findById(id) } returns Optional.empty()
+
+        val ex = assertThrows<NotFoundException> {
+            useCase.execute(DeleteUserUseCase.Command(id))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_NOT_FOUND)
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/usecase/GetUserUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/usecase/GetUserUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Optional
+import java.util.UUID
+
+class GetUserUseCaseTest {
+    private val repo = mockk<UserRepository>()
+    private val useCase = GetUserUseCase(repo)
+
+    @Test
+    fun `returns user when found`() {
+        val user = User.create("a@b.com")
+        every { repo.findById(user.id) } returns Optional.of(user)
+
+        assertThat(useCase.execute(GetUserUseCase.Query(user.id))).isEqualTo(user)
+    }
+
+    @Test
+    fun `throws NotFoundException with USER_NOT_FOUND code`() {
+        val id = UUID.randomUUID()
+        every { repo.findById(id) } returns Optional.empty()
+
+        val ex = assertThrows<NotFoundException> { useCase.execute(GetUserUseCase.Query(id)) }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_NOT_FOUND)
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/usecase/UpdateUserUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/usecase/UpdateUserUseCaseTest.kt
@@ -1,0 +1,42 @@
+package com.aibles.iam.identity.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.NotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Optional
+import java.util.UUID
+
+class UpdateUserUseCaseTest {
+    private val repo = mockk<UserRepository>()
+    private val useCase = UpdateUserUseCase(repo)
+
+    @Test
+    fun `updates display name and saves`() {
+        val user = User.create("a@b.com", "Old Name")
+        every { repo.findById(user.id) } returns Optional.of(user)
+        every { repo.save(any()) } answers { firstArg() }
+
+        val result = useCase.execute(UpdateUserUseCase.Command(user.id, "New Name"))
+
+        assertThat(result.user.displayName).isEqualTo("New Name")
+        verify(exactly = 1) { repo.save(user) }
+    }
+
+    @Test
+    fun `throws NotFoundException when user not found`() {
+        val id = UUID.randomUUID()
+        every { repo.findById(id) } returns Optional.empty()
+
+        val ex = assertThrows<NotFoundException> {
+            useCase.execute(UpdateUserUseCase.Command(id, "Name"))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_NOT_FOUND)
+    }
+}


### PR DESCRIPTION
## Summary
- `CreateUserUseCase` — saves new user, throws `USER_EMAIL_CONFLICT` on duplicate email
- `GetUserUseCase` — returns user by ID, throws `USER_NOT_FOUND`
- `UpdateUserUseCase` — updates `displayName`, throws `USER_NOT_FOUND`
- `ChangeUserStatusUseCase` — enables/disables user, throws `USER_NOT_FOUND`
- `DeleteUserUseCase` — deletes user, throws `USER_NOT_FOUND`

## Test Plan
- [x] 10 MockK unit tests (2 per use case: happy path + failure path)
- [x] `./gradlew test --tests "com.aibles.iam.identity.usecase.*"` → BUILD SUCCESSFUL
- [x] Zero `api/` imports in any use case

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)