### PR TITLE
feat(identity): Users REST API with CRUD endpoints

### DIFF
--- a/src/main/kotlin/com/aibles/iam/identity/api/UsersController.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/api/UsersController.kt
@@ -1,0 +1,74 @@
+package com.aibles.iam.identity.api
+
+import com.aibles.iam.identity.api.dto.ChangeStatusRequest
+import com.aibles.iam.identity.api.dto.CreateUserRequest
+import com.aibles.iam.identity.api.dto.UpdateUserRequest
+import com.aibles.iam.identity.api.dto.UserResponse
+import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.identity.usecase.DeleteUserUseCase
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.identity.usecase.UpdateUserUseCase
+import com.aibles.iam.shared.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UsersController(
+    private val getUserUseCase: GetUserUseCase,
+    private val createUserUseCase: CreateUserUseCase,
+    private val updateUserUseCase: UpdateUserUseCase,
+    private val changeUserStatusUseCase: ChangeUserStatusUseCase,
+    private val deleteUserUseCase: DeleteUserUseCase,
+) {
+
+    @GetMapping("/{id}")
+    fun getUser(@PathVariable id: UUID): ApiResponse<UserResponse> {
+        val user = getUserUseCase.execute(GetUserUseCase.Query(id))
+        return ApiResponse.ok(UserResponse.from(user))
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createUser(@Valid @RequestBody request: CreateUserRequest): ApiResponse<UserResponse> {
+        val result = createUserUseCase.execute(
+            CreateUserUseCase.Command(request.email, request.displayName, googleSub = null)
+        )
+        return ApiResponse.ok(UserResponse.from(result.user))
+    }
+
+    @PatchMapping("/{id}")
+    fun updateUser(
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: UpdateUserRequest,
+    ): ApiResponse<UserResponse> {
+        val result = updateUserUseCase.execute(UpdateUserUseCase.Command(id, request.displayName))
+        return ApiResponse.ok(UserResponse.from(result.user))
+    }
+
+    @PatchMapping("/{id}/status")
+    fun changeStatus(
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: ChangeStatusRequest,
+    ): ApiResponse<UserResponse> {
+        val result = changeUserStatusUseCase.execute(ChangeUserStatusUseCase.Command(id, request.status))
+        return ApiResponse.ok(UserResponse.from(result.user))
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteUser(@PathVariable id: UUID) {
+        deleteUserUseCase.execute(DeleteUserUseCase.Command(id))
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/identity/api/dto/ChangeStatusRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/api/dto/ChangeStatusRequest.kt
@@ -1,0 +1,8 @@
+package com.aibles.iam.identity.api.dto
+
+import com.aibles.iam.identity.domain.user.UserStatus
+import jakarta.validation.constraints.NotNull
+
+data class ChangeStatusRequest(
+    @field:NotNull val status: UserStatus,
+)

--- a/src/main/kotlin/com/aibles/iam/identity/api/dto/CreateUserRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/api/dto/CreateUserRequest.kt
@@ -1,0 +1,9 @@
+package com.aibles.iam.identity.api.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class CreateUserRequest(
+    @field:NotBlank @field:Email val email: String,
+    val displayName: String?,
+)

--- a/src/main/kotlin/com/aibles/iam/identity/api/dto/UpdateUserRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/api/dto/UpdateUserRequest.kt
@@ -1,0 +1,7 @@
+package com.aibles.iam.identity.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateUserRequest(
+    @field:NotBlank val displayName: String,
+)

--- a/src/main/kotlin/com/aibles/iam/identity/api/dto/UserResponse.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/api/dto/UserResponse.kt
@@ -1,0 +1,26 @@
+package com.aibles.iam.identity.api.dto
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserStatus
+import java.time.Instant
+import java.util.UUID
+
+data class UserResponse(
+    val id: UUID,
+    val email: String,
+    val displayName: String?,
+    val status: UserStatus,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+) {
+    companion object {
+        fun from(user: User) = UserResponse(
+            id = user.id,
+            email = user.email,
+            displayName = user.displayName,
+            status = user.status,
+            createdAt = user.createdAt,
+            updatedAt = user.updatedAt,
+        )
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/api/UsersControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/api/UsersControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aibles.iam.identity.api
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.identity.usecase.DeleteUserUseCase
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.identity.usecase.UpdateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.GlobalExceptionHandler
+import com.aibles.iam.shared.error.NotFoundException
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.justRun
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import java.util.UUID
+
+@WebMvcTest
+@Import(GlobalExceptionHandler::class, UsersController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class UsersControllerTest {
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @MockkBean lateinit var getUserUseCase: GetUserUseCase
+    @MockkBean lateinit var updateUserUseCase: UpdateUserUseCase
+    @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
+    @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
+    @MockkBean lateinit var createUserUseCase: CreateUserUseCase
+
+    private val testUser = User.create("test@example.com", "Test User")
+
+    @Test
+    fun `GET users-{id} returns user response`() {
+        every { getUserUseCase.execute(GetUserUseCase.Query(testUser.id)) } returns testUser
+
+        mockMvc.get("/api/v1/users/${testUser.id}")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.email") { value("test@example.com") }
+                jsonPath("$.data.displayName") { value("Test User") }
+            }
+    }
+
+    @Test
+    fun `GET users-{id} returns USER_NOT_FOUND for missing user`() {
+        val id = UUID.randomUUID()
+        every { getUserUseCase.execute(GetUserUseCase.Query(id)) } throws
+            NotFoundException("User not found", ErrorCode.USER_NOT_FOUND)
+
+        mockMvc.get("/api/v1/users/$id")
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.success") { value(false) }
+                jsonPath("$.error.code") { value("USER_NOT_FOUND") }
+            }
+    }
+
+    @Test
+    fun `PATCH users-{id} updates display name`() {
+        every { updateUserUseCase.execute(any()) } returns UpdateUserUseCase.Result(testUser)
+
+        mockMvc.patch("/api/v1/users/${testUser.id}") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"displayName": "Updated Name"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+        }
+    }
+
+    @Test
+    fun `DELETE users-{id} returns 204`() {
+        justRun { deleteUserUseCase.execute(DeleteUserUseCase.Command(testUser.id)) }
+
+        mockMvc.delete("/api/v1/users/${testUser.id}")
+            .andExpect { status { isNoContent() } }
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/shared/error/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/shared/error/GlobalExceptionHandlerTest.kt
@@ -1,7 +1,13 @@
 package com.aibles.iam.shared.error
 
+import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.identity.usecase.DeleteUserUseCase
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.identity.usecase.UpdateUserUseCase
 import com.aibles.iam.shared.response.ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -23,11 +29,13 @@ import jakarta.validation.constraints.NotBlank
 @org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc(addFilters = false)
 class GlobalExceptionHandlerTest {
 
-    @Autowired
-    lateinit var mockMvc: MockMvc
-
-    @Autowired
-    lateinit var objectMapper: ObjectMapper
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var objectMapper: ObjectMapper
+    @MockkBean lateinit var getUserUseCase: GetUserUseCase
+    @MockkBean lateinit var updateUserUseCase: UpdateUserUseCase
+    @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
+    @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
+    @MockkBean lateinit var createUserUseCase: CreateUserUseCase
 
     @RestController
     class TestController {


### PR DESCRIPTION
## Summary
- Implements `GET`, `POST`, `PATCH`, `DELETE /api/v1/users` REST endpoints backed by existing use cases
- Adds DTOs: `UserResponse`, `CreateUserRequest`, `UpdateUserRequest`, `ChangeStatusRequest`
- Fixes `GlobalExceptionHandlerTest` to mock `UsersController` use case dependencies (required now that controller is scanned by `@WebMvcTest`)

## Endpoints
| Method | Path | Status | Description |
|--------|------|--------|-------------|
| GET | `/api/v1/users/{id}` | 200 | Get user by ID |
| POST | `/api/v1/users` | 201 | Create user |
| PATCH | `/api/v1/users/{id}` | 200 | Update display name |
| PATCH | `/api/v1/users/{id}/status` | 200 | Change user status |
| DELETE | `/api/v1/users/{id}` | 204 | Delete user |

## Test plan
- [x] `UsersControllerTest`: 4 MockMvc tests (GET success, GET not found, PATCH, DELETE) — all pass
- [x] `GlobalExceptionHandlerTest`: 7 tests — all pass (fixed by adding use case mocks)
- [x] All 32 tests pass: `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #11