### PR TITLE
feat(authorization): JWT service + RSA key loading

### DIFF
--- a/src/main/kotlin/com/aibles/iam/IamApplication.kt
+++ b/src/main/kotlin/com/aibles/iam/IamApplication.kt
@@ -1,9 +1,12 @@
 package com.aibles.iam
 
+import com.aibles.iam.shared.config.JwtProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties::class)
 class IamApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/aibles/iam/authorization/infra/JwtService.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/infra/JwtService.kt
@@ -1,0 +1,69 @@
+package com.aibles.iam.authorization.infra
+
+import com.aibles.iam.shared.config.JwtProperties
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.UnauthorizedException
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtClaimsSet
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.security.oauth2.jwt.JwsHeader
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder
+import org.springframework.stereotype.Component
+import java.security.KeyFactory
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Base64
+import java.util.UUID
+
+@Component
+class JwtService(private val props: JwtProperties) {
+
+    private val encoder: NimbusJwtEncoder
+    private val decoder: NimbusJwtDecoder
+
+    init {
+        val kf = KeyFactory.getInstance("RSA")
+        val privateKey = kf.generatePrivate(
+            PKCS8EncodedKeySpec(Base64.getDecoder().decode(props.privateKey))
+        ) as RSAPrivateKey
+        val publicKey = kf.generatePublic(
+            X509EncodedKeySpec(Base64.getDecoder().decode(props.publicKey))
+        ) as RSAPublicKey
+
+        val rsaKey = RSAKey.Builder(publicKey).privateKey(privateKey).build()
+        encoder = NimbusJwtEncoder(ImmutableJWKSet(JWKSet(rsaKey)))
+        decoder = NimbusJwtDecoder.withPublicKey(publicKey).build()
+    }
+
+    fun generateAccessToken(userId: UUID, email: String, roles: Set<String>): String {
+        val now = Instant.now()
+        val expiry = now.plus(props.accessTokenTtlMinutes, ChronoUnit.MINUTES)
+        val claims = JwtClaimsSet.builder()
+            .subject(userId.toString())
+            .claim("email", email)
+            .claim("roles", roles.toList())
+            .issuedAt(now)
+            .expiresAt(expiry)
+            .build()
+        val header = JwsHeader.with(SignatureAlgorithm.RS256).build()
+        return encoder.encode(JwtEncoderParameters.from(header, claims)).tokenValue
+    }
+
+    fun validate(token: String): Jwt {
+        try {
+            return decoder.decode(token)
+        } catch (e: JwtException) {
+            throw UnauthorizedException(e.message ?: "Invalid token", ErrorCode.TOKEN_INVALID)
+        }
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/shared/config/JwtProperties.kt
+++ b/src/main/kotlin/com/aibles/iam/shared/config/JwtProperties.kt
@@ -1,0 +1,10 @@
+package com.aibles.iam.shared.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("jwt")
+data class JwtProperties(
+    val privateKey: String = "",   // Base64-encoded PKCS#8 DER
+    val publicKey: String = "",    // Base64-encoded X.509 DER
+    val accessTokenTtlMinutes: Long = 15,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,7 @@ management:
     web:
       exposure:
         include: health,info
+jwt:
+  private-key: ${JWT_PRIVATE_KEY:}
+  public-key: ${JWT_PUBLIC_KEY:}
+  access-token-ttl-minutes: ${JWT_TTL_MINUTES:15}

--- a/src/test/kotlin/com/aibles/iam/authorization/infra/JwtServiceTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/infra/JwtServiceTest.kt
@@ -1,0 +1,64 @@
+package com.aibles.iam.authorization.infra
+
+import com.aibles.iam.shared.config.JwtProperties
+import com.aibles.iam.shared.error.UnauthorizedException
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.security.KeyPairGenerator
+import java.time.Instant
+import java.util.Base64
+import java.util.Date
+import java.util.UUID
+
+class JwtServiceTest {
+
+    private val keyPair = KeyPairGenerator.getInstance("RSA")
+        .apply { initialize(2048) }.generateKeyPair()
+
+    private val props = JwtProperties(
+        privateKey = Base64.getEncoder().encodeToString(keyPair.private.encoded),
+        publicKey = Base64.getEncoder().encodeToString(keyPair.public.encoded),
+        accessTokenTtlMinutes = 15,
+    )
+    private val service = JwtService(props)
+
+    @Test
+    fun `generated token contains correct claims`() {
+        val userId = UUID.randomUUID()
+        val token = service.generateAccessToken(userId, "a@b.com", setOf("USER"))
+        val decoded = service.validate(token)
+        assertThat(decoded.subject).isEqualTo(userId.toString())
+        assertThat(decoded.getClaimAsString("email")).isEqualTo("a@b.com")
+    }
+
+    @Test
+    fun `tampered token is rejected with UnauthorizedException`() {
+        val token = service.generateAccessToken(UUID.randomUUID(), "a@b.com", setOf("USER"))
+        val tampered = token.dropLast(5) + "XXXXX"
+        assertThrows<UnauthorizedException> { service.validate(tampered) }
+    }
+
+    @Test
+    fun `expired token is rejected with UnauthorizedException`() {
+        // Build a token that expired 10 minutes ago directly via Nimbus to bypass encoder validation
+        val past = Instant.now().minusSeconds(600)
+        val claims = JWTClaimsSet.Builder()
+            .subject(UUID.randomUUID().toString())
+            .claim("email", "a@b.com")
+            .issueTime(Date.from(past.minusSeconds(60)))
+            .expirationTime(Date.from(past))
+            .build()
+        val header = JWSHeader(JWSAlgorithm.RS256)
+        val signedJWT = SignedJWT(header, claims)
+        signedJWT.sign(RSASSASigner(keyPair.private))
+        val expiredToken = signedJWT.serialize()
+
+        assertThrows<UnauthorizedException> { service.validate(expiredToken) }
+    }
+}


### PR DESCRIPTION
## Summary
- JwtProperties @ConfigurationProperties for jwt.private-key / jwt.public-key / jwt.access-token-ttl-minutes
- JwtService using Nimbus JOSE+JWT (transitive dep — no new library): RS256 sign/validate
- generateAccessToken: embeds sub, email, roles, iat, exp claims
- validate: decodes Jwt or throws UnauthorizedException(TOKEN_INVALID)
- @EnableConfigurationProperties(JwtProperties::class) added to IamApplication

## Test plan
- [x] 3 tests: correct claims, tampered token rejected, expired token rejected
- [x] ./gradlew test → BUILD SUCCESSFUL (all tests pass)

🤖 Generated with Claude Code

Closes #15