### PR TITLE
feat(authorization): Redis refresh token store

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,12 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:2.0.3")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/kotlin/com/aibles/iam/authorization/domain/token/TokenStore.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/domain/token/TokenStore.kt
@@ -1,0 +1,10 @@
+package com.aibles.iam.authorization.domain.token
+
+import java.time.Duration
+import java.util.UUID
+
+interface TokenStore {
+    fun storeRefreshToken(token: String, userId: UUID, ttl: Duration)
+    fun validateAndConsume(token: String): UUID  // atomic get+delete; throws UnauthorizedException(TOKEN_INVALID) if missing/expired
+    fun revokeAllForUser(userId: UUID)
+}

--- a/src/main/kotlin/com/aibles/iam/authorization/infra/RedisTokenStore.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/infra/RedisTokenStore.kt
@@ -1,0 +1,32 @@
+package com.aibles.iam.authorization.infra
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.UnauthorizedException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.UUID
+
+@Component
+class RedisTokenStore(private val template: StringRedisTemplate) : TokenStore {
+
+    override fun storeRefreshToken(token: String, userId: UUID, ttl: Duration) {
+        template.opsForValue().set("rt:$token", userId.toString(), ttl)
+        template.opsForSet().add("rt:u:$userId", token)
+    }
+
+    override fun validateAndConsume(token: String): UUID {
+        val userId = template.opsForValue().getAndDelete("rt:$token")
+            ?: throw UnauthorizedException("Refresh token invalid or expired", ErrorCode.TOKEN_INVALID)
+        return UUID.fromString(userId)
+    }
+
+    override fun revokeAllForUser(userId: UUID) {
+        val tokens = template.opsForSet().members("rt:u:$userId") ?: emptySet()
+        if (tokens.isNotEmpty()) {
+            tokens.forEach { token -> template.delete("rt:$token") }
+        }
+        template.delete("rt:u:$userId")
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/authorization/infra/RedisTokenStoreTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/infra/RedisTokenStoreTest.kt
@@ -1,0 +1,88 @@
+package com.aibles.iam.authorization.infra
+
+import com.aibles.iam.shared.error.UnauthorizedException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.Duration
+import java.util.UUID
+
+@Testcontainers
+class RedisTokenStoreTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> = GenericContainer("redis:7-alpine")
+            .withExposedPorts(6379)
+    }
+
+    private val template: StringRedisTemplate by lazy {
+        val factory = LettuceConnectionFactory("localhost", redis.getMappedPort(6379))
+        factory.afterPropertiesSet()
+        StringRedisTemplate(factory).apply { afterPropertiesSet() }
+    }
+
+    private val store: RedisTokenStore by lazy { RedisTokenStore(template) }
+
+    @AfterEach
+    fun flush() {
+        template.connectionFactory?.connection?.serverCommands()?.flushAll()
+    }
+
+    @Test
+    fun `store and consume returns correct userId`() {
+        val userId = UUID.randomUUID()
+        val token = UUID.randomUUID().toString()
+        store.storeRefreshToken(token, userId, Duration.ofMinutes(30))
+
+        val returned = store.validateAndConsume(token)
+        assertThat(returned).isEqualTo(userId)
+    }
+
+    @Test
+    fun `consuming same token twice throws UnauthorizedException`() {
+        val userId = UUID.randomUUID()
+        val token = UUID.randomUUID().toString()
+        store.storeRefreshToken(token, userId, Duration.ofMinutes(30))
+
+        store.validateAndConsume(token)  // first: success
+
+        assertThrows<UnauthorizedException> {
+            store.validateAndConsume(token)  // second: must fail
+        }
+    }
+
+    @Test
+    fun `expired token throws UnauthorizedException`() {
+        val userId = UUID.randomUUID()
+        val token = UUID.randomUUID().toString()
+        store.storeRefreshToken(token, userId, Duration.ofMillis(100))
+
+        Thread.sleep(500)  // wait beyond TTL
+
+        assertThrows<UnauthorizedException> {
+            store.validateAndConsume(token)
+        }
+    }
+
+    @Test
+    fun `revokeAllForUser removes all tokens for that user`() {
+        val userId = UUID.randomUUID()
+        val t1 = UUID.randomUUID().toString()
+        val t2 = UUID.randomUUID().toString()
+        store.storeRefreshToken(t1, userId, Duration.ofMinutes(30))
+        store.storeRefreshToken(t2, userId, Duration.ofMinutes(30))
+
+        store.revokeAllForUser(userId)
+
+        assertThrows<UnauthorizedException> { store.validateAndConsume(t1) }
+        assertThrows<UnauthorizedException> { store.validateAndConsume(t2) }
+    }
+}


### PR DESCRIPTION
## Summary
- TokenStore interface: storeRefreshToken, validateAndConsume (atomic), revokeAllForUser
- RedisTokenStore: primary key rt:{token}→userId with TTL; secondary set rt:u:{userId} for revoke-all
- validateAndConsume uses getAndDelete for atomicity (no double-consume possible)
- 4 Testcontainers Redis tests: store+consume, double-consume, expired, revokeAllForUser
- Upgraded testcontainers BOM to 2.0.3 (required for Docker API 1.44+ compatibility with Docker 29.x)

## Test plan
- [x] 4 tests pass using real Redis via Testcontainers
- [x] ./gradlew test → BUILD SUCCESSFUL (all tests)

🤖 Generated with Claude Code

Closes #16