### PR TITLE
feat(authorization): token management use cases

### DIFF
--- a/src/main/kotlin/com/aibles/iam/authorization/usecase/IssueTokenUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/usecase/IssueTokenUseCase.kt
@@ -1,0 +1,28 @@
+package com.aibles.iam.authorization.usecase
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.authorization.infra.JwtService
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.shared.config.JwtProperties
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.UUID
+
+@Component
+class IssueTokenUseCase(
+    private val jwtService: JwtService,
+    private val tokenStore: TokenStore,
+    private val props: JwtProperties,
+) {
+    data class Command(val user: User)
+    data class Result(val accessToken: String, val refreshToken: String, val expiresIn: Long)
+
+    fun execute(command: Command): Result {
+        val accessToken = jwtService.generateAccessToken(
+            command.user.id, command.user.email, command.user.roles
+        )
+        val refreshToken = UUID.randomUUID().toString()
+        tokenStore.storeRefreshToken(refreshToken, command.user.id, Duration.ofDays(30))
+        return Result(accessToken, refreshToken, props.accessTokenTtlMinutes * 60)
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/authorization/usecase/RefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/usecase/RefreshTokenUseCase.kt
@@ -1,0 +1,24 @@
+package com.aibles.iam.authorization.usecase
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.ForbiddenException
+import org.springframework.stereotype.Component
+
+@Component
+class RefreshTokenUseCase(
+    private val tokenStore: TokenStore,
+    private val getUserUseCase: GetUserUseCase,
+    private val issueTokenUseCase: IssueTokenUseCase,
+) {
+    data class Command(val refreshToken: String)
+
+    fun execute(command: Command): IssueTokenUseCase.Result {
+        val userId = tokenStore.validateAndConsume(command.refreshToken)
+        val user = getUserUseCase.execute(GetUserUseCase.Query(userId))
+        if (!user.isActive())
+            throw ForbiddenException("Account is disabled", ErrorCode.USER_DISABLED)
+        return issueTokenUseCase.execute(IssueTokenUseCase.Command(user))
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/authorization/usecase/RevokeTokenUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/usecase/RevokeTokenUseCase.kt
@@ -1,0 +1,18 @@
+package com.aibles.iam.authorization.usecase
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.shared.error.UnauthorizedException
+import org.springframework.stereotype.Component
+
+@Component
+class RevokeTokenUseCase(private val tokenStore: TokenStore) {
+    data class Command(val refreshToken: String)
+
+    fun execute(command: Command) {
+        try {
+            tokenStore.validateAndConsume(command.refreshToken)
+        } catch (e: UnauthorizedException) {
+            // already revoked/expired — logout is idempotent
+        }
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/authorization/usecase/IssueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/usecase/IssueTokenUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.aibles.iam.authorization.usecase
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.authorization.infra.JwtService
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.shared.config.JwtProperties
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.security.KeyPairGenerator
+import java.util.Base64
+
+class IssueTokenUseCaseTest {
+
+    private val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+    private val props = JwtProperties(
+        privateKey = Base64.getEncoder().encodeToString(keyPair.private.encoded),
+        publicKey = Base64.getEncoder().encodeToString(keyPair.public.encoded),
+        accessTokenTtlMinutes = 15,
+    )
+    private val jwtService = JwtService(props)
+    private val tokenStore = mockk<TokenStore>()
+    private val useCase = IssueTokenUseCase(jwtService, tokenStore, props)
+
+    @Test
+    fun `issues access and refresh tokens for user`() {
+        val user = User.create("a@b.com")
+        justRun { tokenStore.storeRefreshToken(any(), user.id, any()) }
+
+        val result = useCase.execute(IssueTokenUseCase.Command(user))
+
+        assertThat(result.accessToken).isNotBlank()
+        assertThat(result.refreshToken).isNotBlank()
+        assertThat(result.expiresIn).isEqualTo(15L * 60)
+        verify(exactly = 1) { tokenStore.storeRefreshToken(result.refreshToken, user.id, any()) }
+    }
+
+    @Test
+    fun `access token contains correct sub and email claims`() {
+        val user = User.create("b@example.com")
+        justRun { tokenStore.storeRefreshToken(any(), any(), any()) }
+
+        val result = useCase.execute(IssueTokenUseCase.Command(user))
+        val decoded = jwtService.validate(result.accessToken)
+
+        assertThat(decoded.subject).isEqualTo(user.id.toString())
+        assertThat(decoded.getClaimAsString("email")).isEqualTo("b@example.com")
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/authorization/usecase/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/usecase/RefreshTokenUseCaseTest.kt
@@ -1,0 +1,69 @@
+package com.aibles.iam.authorization.usecase
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.authorization.infra.JwtService
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.shared.config.JwtProperties
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.ForbiddenException
+import com.aibles.iam.shared.error.UnauthorizedException
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.security.KeyPairGenerator
+import java.util.Base64
+
+class RefreshTokenUseCaseTest {
+
+    private val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+    private val props = JwtProperties(
+        privateKey = Base64.getEncoder().encodeToString(keyPair.private.encoded),
+        publicKey = Base64.getEncoder().encodeToString(keyPair.public.encoded),
+        accessTokenTtlMinutes = 15,
+    )
+    private val tokenStore = mockk<TokenStore>()
+    private val getUserUseCase = mockk<GetUserUseCase>()
+    private val jwtService = JwtService(props)
+    private val issueToken = IssueTokenUseCase(jwtService, tokenStore, props)
+    private val useCase = RefreshTokenUseCase(tokenStore, getUserUseCase, issueToken)
+
+    @Test
+    fun `valid refresh token returns new token pair`() {
+        val user = User.create("a@b.com")
+        every { tokenStore.validateAndConsume("rt-valid") } returns user.id
+        every { getUserUseCase.execute(GetUserUseCase.Query(user.id)) } returns user
+        justRun { tokenStore.storeRefreshToken(any(), user.id, any()) }
+
+        val result = useCase.execute(RefreshTokenUseCase.Command("rt-valid"))
+
+        assertThat(result.accessToken).isNotBlank()
+        assertThat(result.refreshToken).isNotBlank()
+    }
+
+    @Test
+    fun `disabled user throws ForbiddenException with USER_DISABLED`() {
+        val user = User.create("a@b.com").also { it.disable() }
+        every { tokenStore.validateAndConsume("rt-disabled") } returns user.id
+        every { getUserUseCase.execute(GetUserUseCase.Query(user.id)) } returns user
+
+        val ex = assertThrows<ForbiddenException> {
+            useCase.execute(RefreshTokenUseCase.Command("rt-disabled"))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_DISABLED)
+    }
+
+    @Test
+    fun `invalid refresh token propagates UnauthorizedException with TOKEN_INVALID`() {
+        every { tokenStore.validateAndConsume("bad-token") } throws
+            UnauthorizedException("expired", ErrorCode.TOKEN_INVALID)
+
+        val ex = assertThrows<UnauthorizedException> {
+            useCase.execute(RefreshTokenUseCase.Command("bad-token"))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.TOKEN_INVALID)
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/authorization/usecase/RevokeTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/usecase/RevokeTokenUseCaseTest.kt
@@ -1,0 +1,34 @@
+package com.aibles.iam.authorization.usecase
+
+import com.aibles.iam.authorization.domain.token.TokenStore
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.UnauthorizedException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class RevokeTokenUseCaseTest {
+
+    private val tokenStore = mockk<TokenStore>()
+    private val useCase = RevokeTokenUseCase(tokenStore)
+
+    @Test
+    fun `valid token is consumed from store`() {
+        every { tokenStore.validateAndConsume("good-token") } returns UUID.randomUUID()
+
+        useCase.execute(RevokeTokenUseCase.Command("good-token"))
+
+        verify(exactly = 1) { tokenStore.validateAndConsume("good-token") }
+    }
+
+    @Test
+    fun `already-revoked token does not throw (idempotent logout)`() {
+        every { tokenStore.validateAndConsume("gone-token") } throws
+            UnauthorizedException("expired", ErrorCode.TOKEN_INVALID)
+
+        // should NOT throw — logout is idempotent
+        useCase.execute(RevokeTokenUseCase.Command("gone-token"))
+    }
+}


### PR DESCRIPTION
## Summary
- IssueTokenUseCase: generates access JWT + UUID refresh token, stores in Redis (30d TTL)
- RefreshTokenUseCase: validates+consumes refresh token, checks user active, re-issues tokens
- RevokeTokenUseCase: idempotent — consumes refresh token, ignores already-revoked tokens
- 7 MockK tests total (no Spring context), all asserting errorCode on thrown exceptions

## Test plan
- [x] 2 IssueTokenUseCase tests pass
- [x] 3 RefreshTokenUseCase tests pass
- [x] 2 RevokeTokenUseCase tests pass
- [x] ./gradlew test → BUILD SUCCESSFUL

Closes #17