### PR TITLE
feat(authentication): Google OAuth2 + SecurityConfig JWT bearer

### DIFF
--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/TokenResponse.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/TokenResponse.kt
@@ -1,0 +1,7 @@
+package com.aibles.iam.authentication.api.dto
+
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Long,
+)

--- a/src/main/kotlin/com/aibles/iam/authentication/infra/GoogleOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/infra/GoogleOAuth2SuccessHandler.kt
@@ -1,0 +1,33 @@
+package com.aibles.iam.authentication.infra
+
+import com.aibles.iam.authentication.api.dto.TokenResponse
+import com.aibles.iam.authentication.usecase.LoginWithGoogleUseCase
+import com.aibles.iam.shared.response.ApiResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+@Component
+class GoogleOAuth2SuccessHandler(
+    private val loginWithGoogleUseCase: LoginWithGoogleUseCase,
+    private val objectMapper: ObjectMapper,
+) : AuthenticationSuccessHandler {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication,
+    ) {
+        val oidcUser = authentication.principal as OidcUser
+        val result = loginWithGoogleUseCase.execute(LoginWithGoogleUseCase.Command(oidcUser))
+        val body = ApiResponse.ok(TokenResponse(result.accessToken, result.refreshToken, result.expiresIn))
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.status = HttpServletResponse.SC_OK
+        objectMapper.writeValue(response.writer, body)
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/authentication/usecase/LoginWithGoogleUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/usecase/LoginWithGoogleUseCase.kt
@@ -1,0 +1,39 @@
+package com.aibles.iam.authentication.usecase
+
+import com.aibles.iam.authorization.usecase.IssueTokenUseCase
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.ForbiddenException
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.stereotype.Component
+
+@Component
+class LoginWithGoogleUseCase(
+    private val userRepository: UserRepository,
+    private val createUserUseCase: CreateUserUseCase,
+    private val issueTokenUseCase: IssueTokenUseCase,
+) {
+    data class Command(val oidcUser: OidcUser)
+    data class Result(val accessToken: String, val refreshToken: String, val expiresIn: Long)
+
+    fun execute(command: Command): Result {
+        val oidcUser = command.oidcUser
+        val googleSub = oidcUser.subject
+        val email = oidcUser.email ?: error("Google OIDC user missing email")
+        val name = oidcUser.fullName
+
+        val user = userRepository.findByGoogleSub(googleSub)
+            ?: userRepository.findByEmail(email)
+            ?: createUserUseCase.execute(CreateUserUseCase.Command(email, name, googleSub)).user
+
+        if (!user.isActive())
+            throw ForbiddenException("Account is disabled", ErrorCode.USER_DISABLED)
+
+        user.recordLogin()
+        userRepository.save(user)
+
+        val tokens = issueTokenUseCase.execute(IssueTokenUseCase.Command(user))
+        return Result(tokens.accessToken, tokens.refreshToken, tokens.expiresIn)
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
@@ -1,20 +1,59 @@
 package com.aibles.iam.shared.config
 
+import com.aibles.iam.authentication.infra.GoogleOAuth2SuccessHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.security.web.SecurityFilterChain
+import java.security.KeyFactory
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val jwtProperties: JwtProperties,
+    private val googleOAuth2SuccessHandler: GoogleOAuth2SuccessHandler,
+) {
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
-            .authorizeHttpRequests { it.anyRequest().permitAll() }
             .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers(
+                        "/oauth2/**", "/login/**",
+                        "/api/v1/auth/**",
+                        "/actuator/**",
+                        "/swagger-ui/**", "/v3/api-docs/**",
+                    ).permitAll()
+                    .anyRequest().authenticated()
+            }
+            .oauth2Login { it.successHandler(googleOAuth2SuccessHandler) }
+            .oauth2ResourceServer { it.jwt { jwt -> jwt.decoder(jwtDecoder()) } }
         return http.build()
+    }
+
+    @Bean
+    fun jwtDecoder(): NimbusJwtDecoder {
+        if (jwtProperties.publicKey.isBlank()) {
+            // Fallback for test environments where JWT_PUBLIC_KEY is not configured
+            return NimbusJwtDecoder.withPublicKey(generateTestKey()).build()
+        }
+        val publicKey = KeyFactory.getInstance("RSA")
+            .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(jwtProperties.publicKey))) as RSAPublicKey
+        return NimbusJwtDecoder.withPublicKey(publicKey).build()
+    }
+
+    private fun generateTestKey(): RSAPublicKey {
+        val kpg = java.security.KeyPairGenerator.getInstance("RSA")
+        kpg.initialize(2048)
+        return kpg.generateKeyPair().public as RSAPublicKey
     }
 }

--- a/src/test/kotlin/com/aibles/iam/authentication/usecase/LoginWithGoogleUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authentication/usecase/LoginWithGoogleUseCaseTest.kt
@@ -1,0 +1,87 @@
+package com.aibles.iam.authentication.usecase
+
+import com.aibles.iam.authorization.usecase.IssueTokenUseCase
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.ForbiddenException
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
+import java.time.Instant
+
+class LoginWithGoogleUseCaseTest {
+
+    private val userRepository = mockk<UserRepository>()
+    private val createUserUseCase = mockk<CreateUserUseCase>()
+    private val issueTokenUseCase = mockk<IssueTokenUseCase>()
+    private val useCase = LoginWithGoogleUseCase(userRepository, createUserUseCase, issueTokenUseCase)
+
+    private fun oidcUser(sub: String, email: String, name: String? = "Test User"): DefaultOidcUser {
+        val claims = mutableMapOf<String, Any>(
+            "sub" to sub,
+            "iss" to "https://accounts.google.com",
+        )
+        val idToken = OidcIdToken("token-value", Instant.now(), Instant.now().plusSeconds(3600), claims)
+        val userInfoClaims = mutableMapOf<String, Any>(
+            "sub" to sub,
+            "email" to email,
+        )
+        if (name != null) userInfoClaims["name"] = name
+        val userInfo = OidcUserInfo(userInfoClaims)
+        val authority = OidcUserAuthority(idToken, userInfo)
+        return DefaultOidcUser(listOf(authority), idToken, userInfo, "sub")
+    }
+
+    @Test
+    fun `new user is created on first Google login`() {
+        val oidcUser = oidcUser("sub-new", "new@example.com", "New User")
+        val newUser = User.create("new@example.com", "New User")
+        every { userRepository.findByGoogleSub("sub-new") } returns null
+        every { userRepository.findByEmail("new@example.com") } returns null
+        every { createUserUseCase.execute(any()) } returns CreateUserUseCase.Result(newUser)
+        every { userRepository.save(newUser) } returns newUser
+        every { issueTokenUseCase.execute(any()) } returns IssueTokenUseCase.Result("access", "refresh", 900)
+
+        val result = useCase.execute(LoginWithGoogleUseCase.Command(oidcUser))
+
+        assertThat(result.accessToken).isEqualTo("access")
+        verify(exactly = 1) { createUserUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `existing user by googleSub is returned on second login without creating new user`() {
+        val existingUser = User.create("existing@example.com", "Alice", "sub-existing")
+        val oidcUser = oidcUser("sub-existing", "existing@example.com", "Alice")
+        every { userRepository.findByGoogleSub("sub-existing") } returns existingUser
+        every { userRepository.save(existingUser) } returns existingUser
+        every { issueTokenUseCase.execute(any()) } returns IssueTokenUseCase.Result("access2", "refresh2", 900)
+
+        val result = useCase.execute(LoginWithGoogleUseCase.Command(oidcUser))
+
+        assertThat(result.accessToken).isEqualTo("access2")
+        verify(exactly = 0) { createUserUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `disabled user throws ForbiddenException with USER_DISABLED`() {
+        val disabledUser = User.create("disabled@example.com").also { it.disable() }
+        val oidcUser = oidcUser("sub-disabled", "disabled@example.com")
+        every { userRepository.findByGoogleSub("sub-disabled") } returns disabledUser
+        every { userRepository.save(disabledUser) } returns disabledUser
+
+        val ex = assertThrows<ForbiddenException> {
+            useCase.execute(LoginWithGoogleUseCase.Command(oidcUser))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_DISABLED)
+    }
+}


### PR DESCRIPTION
## Summary
- LoginWithGoogleUseCase: find-or-create user by googleSub/email, recordLogin, issue JWT+refresh tokens
- GoogleOAuth2SuccessHandler: writes ApiResponse<TokenResponse> JSON on successful OAuth2 login
- SecurityConfig: replaced permit-all placeholder with JWT bearer auth; OAuth2 login with custom handler; stateless sessions; /api/v1/auth/**, /oauth2/**, /actuator/** permitted
- TokenResponse DTO for auth responses

## Test plan
- [x] 3 LoginWithGoogleUseCaseTest tests pass (new user, existing user, disabled user)
- [x] ./gradlew test → BUILD SUCCESSFUL

Closes #18