### PR TITLE
feat(authentication): Auth REST controller (refresh + logout)

### DIFF
--- a/src/main/kotlin/com/aibles/iam/authentication/api/AuthController.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/AuthController.kt
@@ -1,0 +1,35 @@
+package com.aibles.iam.authentication.api
+
+import com.aibles.iam.authentication.api.dto.LogoutRequest
+import com.aibles.iam.authentication.api.dto.RefreshTokenRequest
+import com.aibles.iam.authentication.api.dto.TokenResponse
+import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
+import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
+import com.aibles.iam.shared.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    private val refreshTokenUseCase: RefreshTokenUseCase,
+    private val revokeTokenUseCase: RevokeTokenUseCase,
+) {
+
+    @PostMapping("/refresh")
+    fun refresh(@Valid @RequestBody request: RefreshTokenRequest): ApiResponse<TokenResponse> {
+        val result = refreshTokenUseCase.execute(RefreshTokenUseCase.Command(request.refreshToken))
+        return ApiResponse.ok(TokenResponse(result.accessToken, result.refreshToken, result.expiresIn))
+    }
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun logout(@Valid @RequestBody request: LogoutRequest) {
+        revokeTokenUseCase.execute(RevokeTokenUseCase.Command(request.refreshToken))
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/LogoutRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/LogoutRequest.kt
@@ -1,0 +1,5 @@
+package com.aibles.iam.authentication.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class LogoutRequest(@field:NotBlank val refreshToken: String)

--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/RefreshTokenRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/RefreshTokenRequest.kt
@@ -1,0 +1,5 @@
+package com.aibles.iam.authentication.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class RefreshTokenRequest(@field:NotBlank val refreshToken: String)

--- a/src/test/kotlin/com/aibles/iam/authentication/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authentication/api/AuthControllerTest.kt
@@ -1,0 +1,87 @@
+package com.aibles.iam.authentication.api
+
+import com.aibles.iam.authorization.usecase.IssueTokenUseCase
+import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
+import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
+import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.identity.usecase.DeleteUserUseCase
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.identity.usecase.UpdateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.GlobalExceptionHandler
+import com.aibles.iam.shared.error.UnauthorizedException
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.justRun
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+
+@WebMvcTest
+@Import(GlobalExceptionHandler::class, AuthController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired lateinit var mockMvc: MockMvc
+
+    // AuthController deps
+    @MockkBean lateinit var refreshTokenUseCase: RefreshTokenUseCase
+    @MockkBean lateinit var revokeTokenUseCase: RevokeTokenUseCase
+
+    // UsersController deps (scanned by @WebMvcTest — must be mocked)
+    @MockkBean lateinit var getUserUseCase: GetUserUseCase
+    @MockkBean lateinit var updateUserUseCase: UpdateUserUseCase
+    @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
+    @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
+    @MockkBean lateinit var createUserUseCase: CreateUserUseCase
+
+    @Test
+    fun `POST refresh returns 200 with new token pair`() {
+        every { refreshTokenUseCase.execute(any()) } returns
+            IssueTokenUseCase.Result("new-access", "new-refresh", 900)
+
+        mockMvc.post("/api/v1/auth/refresh") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"refreshToken":"old-token"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.accessToken") { value("new-access") }
+            jsonPath("$.data.refreshToken") { value("new-refresh") }
+            jsonPath("$.data.expiresIn") { value(900) }
+        }
+    }
+
+    @Test
+    fun `POST refresh with invalid token returns 401 with TOKEN_INVALID`() {
+        every { refreshTokenUseCase.execute(any()) } throws
+            UnauthorizedException("Token invalid", ErrorCode.TOKEN_INVALID)
+
+        mockMvc.post("/api/v1/auth/refresh") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"refreshToken":"bad-token"}"""
+        }.andExpect {
+            status { isUnauthorized() }
+            jsonPath("$.success") { value(false) }
+            jsonPath("$.error.code") { value("TOKEN_INVALID") }
+        }
+    }
+
+    @Test
+    fun `POST logout returns 204 No Content`() {
+        justRun { revokeTokenUseCase.execute(any()) }
+
+        mockMvc.post("/api/v1/auth/logout") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"refreshToken":"some-token"}"""
+        }.andExpect {
+            status { isNoContent() }
+        }
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/api/UsersControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/api/UsersControllerTest.kt
@@ -1,6 +1,8 @@
 package com.aibles.iam.identity.api
 
 import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
+import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
 import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
 import com.aibles.iam.identity.usecase.CreateUserUseCase
 import com.aibles.iam.identity.usecase.DeleteUserUseCase
@@ -35,6 +37,10 @@ class UsersControllerTest {
     @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
     @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
     @MockkBean lateinit var createUserUseCase: CreateUserUseCase
+
+    // AuthController deps (scanned by @WebMvcTest — must be mocked)
+    @MockkBean lateinit var refreshTokenUseCase: RefreshTokenUseCase
+    @MockkBean lateinit var revokeTokenUseCase: RevokeTokenUseCase
 
     private val testUser = User.create("test@example.com", "Test User")
 

--- a/src/test/kotlin/com/aibles/iam/shared/error/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/shared/error/GlobalExceptionHandlerTest.kt
@@ -1,5 +1,7 @@
 package com.aibles.iam.shared.error
 
+import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
+import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
 import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
 import com.aibles.iam.identity.usecase.CreateUserUseCase
 import com.aibles.iam.identity.usecase.DeleteUserUseCase
@@ -36,6 +38,10 @@ class GlobalExceptionHandlerTest {
     @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
     @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
     @MockkBean lateinit var createUserUseCase: CreateUserUseCase
+
+    // AuthController deps (scanned by @WebMvcTest — must be mocked)
+    @MockkBean lateinit var refreshTokenUseCase: RefreshTokenUseCase
+    @MockkBean lateinit var revokeTokenUseCase: RevokeTokenUseCase
 
     @RestController
     class TestController {


### PR DESCRIPTION
## Summary
- POST /api/v1/auth/refresh — returns 200 with new ApiResponse<TokenResponse> (accessToken, refreshToken, expiresIn)
- POST /api/v1/auth/logout — returns 204 No Content (idempotent)
- Input validation: @NotBlank on refreshToken field in RefreshTokenRequest and LogoutRequest DTOs
- Fixed @WebMvcTest sibling test classes (GlobalExceptionHandlerTest, UsersControllerTest) to mock new AuthController dependencies

## Test plan
- [x] 3 AuthControllerTest tests pass (refresh success, refresh 401 TOKEN_INVALID, logout 204)
- [x] GlobalExceptionHandlerTest — added @MockkBean for RefreshTokenUseCase and RevokeTokenUseCase
- [x] UsersControllerTest — added @MockkBean for RefreshTokenUseCase and RevokeTokenUseCase
- [x] ./gradlew test → BUILD SUCCESSFUL (52 tests, 0 failures)

Closes #19