### PR TITLE
feat(authentication): Passkey REST controller + SecurityConfig narrowed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("io.mockk:mockk:1.13.13")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
     testImplementation("org.testcontainers:postgresql")

--- a/src/main/kotlin/com/aibles/iam/authentication/api/PasskeyController.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/PasskeyController.kt
@@ -1,0 +1,113 @@
+package com.aibles.iam.authentication.api
+
+import com.aibles.iam.authentication.api.dto.AuthenticateFinishRequest
+import com.aibles.iam.authentication.api.dto.PasskeyCredentialResponse
+import com.aibles.iam.authentication.api.dto.RegisterFinishRequest
+import com.aibles.iam.authentication.api.dto.RegisterStartRequest
+import com.aibles.iam.authentication.api.dto.TokenResponse
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredentialRepository
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyStartUseCase
+import com.aibles.iam.authentication.usecase.DeletePasskeyUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyStartUseCase
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.shared.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/auth/passkey")
+class PasskeyController(
+    private val registerPasskeyStartUseCase: RegisterPasskeyStartUseCase,
+    private val registerPasskeyFinishUseCase: RegisterPasskeyFinishUseCase,
+    private val authenticatePasskeyStartUseCase: AuthenticatePasskeyStartUseCase,
+    private val authenticatePasskeyFinishUseCase: AuthenticatePasskeyFinishUseCase,
+    private val deletePasskeyUseCase: DeletePasskeyUseCase,
+    private val credentialRepository: PasskeyCredentialRepository,
+    private val getUserUseCase: GetUserUseCase,
+) {
+
+    @PostMapping("/register/start")
+    fun registerStart(
+        @AuthenticationPrincipal principal: Jwt,
+        @RequestBody request: RegisterStartRequest,
+    ): ApiResponse<RegisterPasskeyStartUseCase.Result> {
+        val userId = UUID.fromString(principal.subject)
+        val user = getUserUseCase.execute(GetUserUseCase.Query(userId))
+        val result = registerPasskeyStartUseCase.execute(
+            RegisterPasskeyStartUseCase.Command(userId, user.email, request.displayName)
+        )
+        return ApiResponse.ok(result)
+    }
+
+    @PostMapping("/register/finish")
+    fun registerFinish(
+        @AuthenticationPrincipal principal: Jwt,
+        @Valid @RequestBody request: RegisterFinishRequest,
+    ): ApiResponse<Unit> {
+        val userId = UUID.fromString(principal.subject)
+        registerPasskeyFinishUseCase.execute(
+            RegisterPasskeyFinishUseCase.Command(
+                userId = userId,
+                sessionId = request.sessionId,
+                clientDataJSON = request.clientDataJSON,
+                attestationObject = request.attestationObject,
+                displayName = request.displayName,
+            )
+        )
+        return ApiResponse.ok(Unit)
+    }
+
+    @PostMapping("/authenticate/start")
+    fun authenticateStart(): ApiResponse<AuthenticatePasskeyStartUseCase.Result> =
+        ApiResponse.ok(authenticatePasskeyStartUseCase.execute())
+
+    @PostMapping("/authenticate/finish")
+    fun authenticateFinish(
+        @Valid @RequestBody request: AuthenticateFinishRequest,
+    ): ApiResponse<TokenResponse> {
+        val result = authenticatePasskeyFinishUseCase.execute(
+            AuthenticatePasskeyFinishUseCase.Command(
+                credentialId = request.credentialId,
+                sessionId = request.sessionId,
+                clientDataJSON = request.clientDataJSON,
+                authenticatorData = request.authenticatorData,
+                signature = request.signature,
+                userHandle = request.userHandle,
+            )
+        )
+        return ApiResponse.ok(TokenResponse(result.accessToken, result.refreshToken, result.expiresIn))
+    }
+
+    @GetMapping("/credentials")
+    fun listCredentials(
+        @AuthenticationPrincipal principal: Jwt,
+    ): ApiResponse<List<PasskeyCredentialResponse>> {
+        val userId = UUID.fromString(principal.subject)
+        val credentials = credentialRepository.findAllByUserId(userId)
+            .map { PasskeyCredentialResponse.from(it) }
+        return ApiResponse.ok(credentials)
+    }
+
+    @DeleteMapping("/credentials/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteCredential(
+        @AuthenticationPrincipal principal: Jwt,
+        @PathVariable id: UUID,
+    ) {
+        val userId = UUID.fromString(principal.subject)
+        deletePasskeyUseCase.execute(DeletePasskeyUseCase.Command(userId, id))
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/AuthenticateFinishRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/AuthenticateFinishRequest.kt
@@ -1,0 +1,12 @@
+package com.aibles.iam.authentication.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class AuthenticateFinishRequest(
+    @field:NotBlank val credentialId: String,
+    @field:NotBlank val sessionId: String,
+    @field:NotBlank val clientDataJSON: String,
+    @field:NotBlank val authenticatorData: String,
+    @field:NotBlank val signature: String,
+    val userHandle: String? = null,
+)

--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/PasskeyCredentialResponse.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/PasskeyCredentialResponse.kt
@@ -1,0 +1,24 @@
+package com.aibles.iam.authentication.api.dto
+
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredential
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+data class PasskeyCredentialResponse(
+    val id: UUID,
+    val credentialId: String,
+    val displayName: String?,
+    val createdAt: Instant,
+    val lastUsedAt: Instant?,
+) {
+    companion object {
+        fun from(cred: PasskeyCredential) = PasskeyCredentialResponse(
+            id = cred.id,
+            credentialId = Base64.getUrlEncoder().withoutPadding().encodeToString(cred.credentialId),
+            displayName = cred.displayName,
+            createdAt = cred.createdAt,
+            lastUsedAt = cred.lastUsedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/RegisterFinishRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/RegisterFinishRequest.kt
@@ -1,0 +1,10 @@
+package com.aibles.iam.authentication.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class RegisterFinishRequest(
+    @field:NotBlank val sessionId: String,
+    @field:NotBlank val clientDataJSON: String,
+    @field:NotBlank val attestationObject: String,
+    val displayName: String? = null,
+)

--- a/src/main/kotlin/com/aibles/iam/authentication/api/dto/RegisterStartRequest.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/dto/RegisterStartRequest.kt
@@ -1,0 +1,3 @@
+package com.aibles.iam.authentication.api.dto
+
+data class RegisterStartRequest(val displayName: String? = null)

--- a/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
@@ -29,7 +29,10 @@ class SecurityConfig(
                 auth
                     .requestMatchers(
                         "/oauth2/**", "/login/**",
-                        "/api/v1/auth/**",
+                        "/api/v1/auth/refresh",
+                        "/api/v1/auth/logout",
+                        "/api/v1/auth/passkey/authenticate/start",
+                        "/api/v1/auth/passkey/authenticate/finish",
                         "/actuator/**",
                         "/swagger-ui/**", "/v3/api-docs/**",
                     ).permitAll()

--- a/src/test/kotlin/com/aibles/iam/authentication/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authentication/api/AuthControllerTest.kt
@@ -1,5 +1,11 @@
 package com.aibles.iam.authentication.api
 
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredentialRepository
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyStartUseCase
+import com.aibles.iam.authentication.usecase.DeletePasskeyUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyStartUseCase
 import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
 import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
 import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
@@ -40,6 +46,14 @@ class AuthControllerTest {
     @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
     @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
     @MockkBean lateinit var createUserUseCase: CreateUserUseCase
+
+    // PasskeyController deps (scanned by @WebMvcTest — must be mocked)
+    @MockkBean lateinit var registerPasskeyStartUseCase: RegisterPasskeyStartUseCase
+    @MockkBean lateinit var registerPasskeyFinishUseCase: RegisterPasskeyFinishUseCase
+    @MockkBean lateinit var authenticatePasskeyStartUseCase: AuthenticatePasskeyStartUseCase
+    @MockkBean lateinit var authenticatePasskeyFinishUseCase: AuthenticatePasskeyFinishUseCase
+    @MockkBean lateinit var deletePasskeyUseCase: DeletePasskeyUseCase
+    @MockkBean lateinit var passkeyCredentialRepository: PasskeyCredentialRepository
 
     @Test
     fun `POST refresh returns 200 with new token pair`() {

--- a/src/test/kotlin/com/aibles/iam/authentication/api/PasskeyControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authentication/api/PasskeyControllerTest.kt
@@ -1,0 +1,171 @@
+package com.aibles.iam.authentication.api
+
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredential
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredentialRepository
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyStartUseCase
+import com.aibles.iam.authentication.usecase.DeletePasskeyUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyStartUseCase
+import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
+import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
+import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.identity.usecase.DeleteUserUseCase
+import com.aibles.iam.identity.usecase.GetUserUseCase
+import com.aibles.iam.identity.usecase.UpdateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.GlobalExceptionHandler
+import com.aibles.iam.shared.error.NotFoundException
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.justRun
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.util.UUID
+
+@WebMvcTest
+@Import(GlobalExceptionHandler::class, PasskeyController::class)
+@AutoConfigureMockMvc(addFilters = false)
+class PasskeyControllerTest {
+
+    @Autowired lateinit var mockMvc: MockMvc
+
+    // PasskeyController deps
+    @MockkBean lateinit var registerPasskeyStartUseCase: RegisterPasskeyStartUseCase
+    @MockkBean lateinit var registerPasskeyFinishUseCase: RegisterPasskeyFinishUseCase
+    @MockkBean lateinit var authenticatePasskeyStartUseCase: AuthenticatePasskeyStartUseCase
+    @MockkBean lateinit var authenticatePasskeyFinishUseCase: AuthenticatePasskeyFinishUseCase
+    @MockkBean lateinit var deletePasskeyUseCase: DeletePasskeyUseCase
+    @MockkBean lateinit var credentialRepository: PasskeyCredentialRepository
+    @MockkBean lateinit var getUserUseCase: GetUserUseCase
+
+    // AuthController deps (scanned by @WebMvcTest)
+    @MockkBean lateinit var refreshTokenUseCase: RefreshTokenUseCase
+    @MockkBean lateinit var revokeTokenUseCase: RevokeTokenUseCase
+
+    // UsersController deps (scanned by @WebMvcTest)
+    @MockkBean lateinit var updateUserUseCase: UpdateUserUseCase
+    @MockkBean lateinit var changeUserStatusUseCase: ChangeUserStatusUseCase
+    @MockkBean lateinit var deleteUserUseCase: DeleteUserUseCase
+    @MockkBean lateinit var createUserUseCase: CreateUserUseCase
+
+    private val userId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUpSecurityContext() {
+        val jwt = Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .subject(userId.toString())
+            .build()
+        val context = SecurityContextHolder.createEmptyContext()
+        context.authentication = JwtAuthenticationToken(jwt)
+        SecurityContextHolder.setContext(context)
+    }
+
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `POST register-start returns 200 with sessionId and options`() {
+        every { getUserUseCase.execute(GetUserUseCase.Query(userId)) } returns
+            com.aibles.iam.identity.domain.user.User.create("user@test.com", "Test User")
+        every { registerPasskeyStartUseCase.execute(any()) } returns
+            RegisterPasskeyStartUseCase.Result(
+                sessionId = "sess-1", rpId = "localhost", rpName = "Test",
+                userId = userId.toString(), userEmail = "user@test.com", userDisplayName = null,
+                challenge = "Y2hhbGxlbmdl",
+            )
+
+        mockMvc.post("/api/v1/auth/passkey/register/start") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"displayName": "My Key"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.sessionId") { value("sess-1") }
+            jsonPath("$.data.challenge") { value("Y2hhbGxlbmdl") }
+        }
+    }
+
+    @Test
+    fun `POST register-finish returns 200`() {
+        justRun { registerPasskeyFinishUseCase.execute(any()) }
+
+        mockMvc.post("/api/v1/auth/passkey/register/finish") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"sessionId":"s","clientDataJSON":"dA==","attestationObject":"dA=="}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+        }
+    }
+
+    @Test
+    fun `POST authenticate-start returns 200 without auth`() {
+        every { authenticatePasskeyStartUseCase.execute() } returns
+            AuthenticatePasskeyStartUseCase.Result(sessionId = "sess-2", rpId = "localhost", challenge = "Y2g=")
+
+        mockMvc.post("/api/v1/auth/passkey/authenticate/start") {
+            contentType = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data.sessionId") { value("sess-2") }
+        }
+    }
+
+    @Test
+    fun `POST authenticate-finish returns 200 with token pair`() {
+        every { authenticatePasskeyFinishUseCase.execute(any()) } returns
+            AuthenticatePasskeyFinishUseCase.Result("access-tok", "refresh-tok", 900)
+
+        mockMvc.post("/api/v1/auth/passkey/authenticate/finish") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"credentialId":"AQID","sessionId":"s","clientDataJSON":"dA==","authenticatorData":"dA==","signature":"dA=="}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data.accessToken") { value("access-tok") }
+            jsonPath("$.data.refreshToken") { value("refresh-tok") }
+        }
+    }
+
+    @Test
+    fun `GET credentials returns list of passkeys`() {
+        every { credentialRepository.findAllByUserId(userId) } returns emptyList()
+
+        mockMvc.get("/api/v1/auth/passkey/credentials") {
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data") { isArray() }
+        }
+    }
+
+    @Test
+    fun `DELETE credentials-{id} not found returns 404`() {
+        val credId = UUID.randomUUID()
+        every { deletePasskeyUseCase.execute(DeletePasskeyUseCase.Command(userId, credId)) } throws
+            NotFoundException("Not found", ErrorCode.PASSKEY_NOT_FOUND)
+
+        mockMvc.delete("/api/v1/auth/passkey/credentials/$credId") {
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.error.code") { value("PASSKEY_NOT_FOUND") }
+        }
+    }
+}

--- a/src/test/kotlin/com/aibles/iam/identity/api/UsersControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/identity/api/UsersControllerTest.kt
@@ -1,6 +1,12 @@
 package com.aibles.iam.identity.api
 
 import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredentialRepository
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyStartUseCase
+import com.aibles.iam.authentication.usecase.DeletePasskeyUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyStartUseCase
 import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
 import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
 import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
@@ -41,6 +47,14 @@ class UsersControllerTest {
     // AuthController deps (scanned by @WebMvcTest — must be mocked)
     @MockkBean lateinit var refreshTokenUseCase: RefreshTokenUseCase
     @MockkBean lateinit var revokeTokenUseCase: RevokeTokenUseCase
+
+    // PasskeyController deps (scanned by @WebMvcTest — must be mocked)
+    @MockkBean lateinit var registerPasskeyStartUseCase: RegisterPasskeyStartUseCase
+    @MockkBean lateinit var registerPasskeyFinishUseCase: RegisterPasskeyFinishUseCase
+    @MockkBean lateinit var authenticatePasskeyStartUseCase: AuthenticatePasskeyStartUseCase
+    @MockkBean lateinit var authenticatePasskeyFinishUseCase: AuthenticatePasskeyFinishUseCase
+    @MockkBean lateinit var deletePasskeyUseCase: DeletePasskeyUseCase
+    @MockkBean lateinit var passkeyCredentialRepository: PasskeyCredentialRepository
 
     private val testUser = User.create("test@example.com", "Test User")
 

--- a/src/test/kotlin/com/aibles/iam/shared/error/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/shared/error/GlobalExceptionHandlerTest.kt
@@ -1,5 +1,11 @@
 package com.aibles.iam.shared.error
 
+import com.aibles.iam.authentication.domain.passkey.PasskeyCredentialRepository
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.AuthenticatePasskeyStartUseCase
+import com.aibles.iam.authentication.usecase.DeletePasskeyUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyFinishUseCase
+import com.aibles.iam.authentication.usecase.RegisterPasskeyStartUseCase
 import com.aibles.iam.authorization.usecase.RefreshTokenUseCase
 import com.aibles.iam.authorization.usecase.RevokeTokenUseCase
 import com.aibles.iam.identity.usecase.ChangeUserStatusUseCase
@@ -42,6 +48,14 @@ class GlobalExceptionHandlerTest {
     // AuthController deps (scanned by @WebMvcTest — must be mocked)
     @MockkBean lateinit var refreshTokenUseCase: RefreshTokenUseCase
     @MockkBean lateinit var revokeTokenUseCase: RevokeTokenUseCase
+
+    // PasskeyController deps (scanned by @WebMvcTest — must be mocked)
+    @MockkBean lateinit var registerPasskeyStartUseCase: RegisterPasskeyStartUseCase
+    @MockkBean lateinit var registerPasskeyFinishUseCase: RegisterPasskeyFinishUseCase
+    @MockkBean lateinit var authenticatePasskeyStartUseCase: AuthenticatePasskeyStartUseCase
+    @MockkBean lateinit var authenticatePasskeyFinishUseCase: AuthenticatePasskeyFinishUseCase
+    @MockkBean lateinit var deletePasskeyUseCase: DeletePasskeyUseCase
+    @MockkBean lateinit var passkeyCredentialRepository: PasskeyCredentialRepository
 
     @RestController
     class TestController {


### PR DESCRIPTION
Closes #33

## Changes

**`PasskeyController`** — 6 endpoints under `/api/v1/auth/passkey/`:
- `POST /register/start` — requires JWT (returns challenge options)
- `POST /register/finish` — requires JWT (verifies attestation, saves credential)
- `POST /authenticate/start` — public (returns challenge options for login)
- `POST /authenticate/finish` — public (verifies assertion, returns token pair)
- `GET /credentials` — requires JWT (lists user's passkeys)
- `DELETE /credentials/{id}` — requires JWT (removes passkey)

**DTOs**: `RegisterStartRequest`, `RegisterFinishRequest`, `AuthenticateFinishRequest`, `PasskeyCredentialResponse`

**`SecurityConfig`**: narrowed broad `/api/v1/auth/**` permit-all to specific paths: `refresh`, `logout`, `authenticate/start`, `authenticate/finish`. Register and credentials endpoints now require JWT.

**Testing**: `PasskeyControllerTest` with 6 tests. Uses `SecurityContextHolder` + `JwtAuthenticationToken` in `@BeforeEach` to inject JWT principal with `addFilters=false`. Added `@MockkBean` for all PasskeyController deps to `UsersControllerTest`, `AuthControllerTest`, `GlobalExceptionHandlerTest`. Added `spring-security-test` to test dependencies.