### PR TITLE
feat(authorization): Spring Authorization Server config + V2 schema migration

### DIFF
--- a/src/main/kotlin/com/aibles/iam/authorization/infra/authserver/AuthorizationServerConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/infra/authserver/AuthorizationServerConfig.kt
@@ -1,0 +1,96 @@
+package com.aibles.iam.authorization.infra.authserver
+
+import com.aibles.iam.shared.config.JwtProperties
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet
+import com.nimbusds.jose.jwk.source.JWKSource
+import com.nimbusds.jose.proc.SecurityContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.config.Customizer
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService
+import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint
+import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher
+import java.security.KeyFactory
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import javax.sql.DataSource
+
+@Configuration
+class AuthorizationServerConfig(private val jwtProperties: JwtProperties) {
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    fun authorizationServerSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val configurer = OAuth2AuthorizationServerConfigurer()
+        http
+            .securityMatcher(configurer.endpointsMatcher)
+            .with(configurer) { it.oidc(Customizer.withDefaults()) }
+            .authorizeHttpRequests { it.anyRequest().authenticated() }
+            .exceptionHandling {
+                it.defaultAuthenticationEntryPointFor(
+                    LoginUrlAuthenticationEntryPoint("/oauth2/authorization/google"),
+                    MediaTypeRequestMatcher(MediaType.TEXT_HTML),
+                )
+            }
+        return http.build()
+    }
+
+    @Bean
+    fun jwkSource(): JWKSource<SecurityContext> {
+        val kf = KeyFactory.getInstance("RSA")
+        val privateKey = kf.generatePrivate(
+            PKCS8EncodedKeySpec(Base64.getDecoder().decode(jwtProperties.privateKey))
+        ) as RSAPrivateKey
+        val publicKey = kf.generatePublic(
+            X509EncodedKeySpec(Base64.getDecoder().decode(jwtProperties.publicKey))
+        ) as RSAPublicKey
+        val rsaKey = RSAKey.Builder(publicKey).privateKey(privateKey).keyID("iam-rsa").build()
+        return ImmutableJWKSet(JWKSet(rsaKey))
+    }
+
+    @Bean
+    fun jwtDecoder(jwkSource: JWKSource<SecurityContext>): JwtDecoder =
+        OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource)
+
+    @Bean
+    fun authorizationServerSettings(): AuthorizationServerSettings =
+        AuthorizationServerSettings.builder().build()
+
+    @Bean
+    fun registeredClientRepository(dataSource: DataSource): RegisteredClientRepository =
+        JdbcRegisteredClientRepository(JdbcTemplate(dataSource))
+
+    @Bean
+    fun authorizationService(
+        dataSource: DataSource,
+        registeredClientRepository: RegisteredClientRepository,
+    ): OAuth2AuthorizationService =
+        JdbcOAuth2AuthorizationService(JdbcTemplate(dataSource), registeredClientRepository)
+
+    @Bean
+    fun authorizationConsentService(
+        dataSource: DataSource,
+        registeredClientRepository: RegisteredClientRepository,
+    ): OAuth2AuthorizationConsentService =
+        JdbcOAuth2AuthorizationConsentService(JdbcTemplate(dataSource), registeredClientRepository)
+}

--- a/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
@@ -3,24 +3,22 @@ package com.aibles.iam.shared.config
 import com.aibles.iam.authentication.infra.GoogleOAuth2SuccessHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.web.SecurityFilterChain
-import java.security.KeyFactory
-import java.security.interfaces.RSAPublicKey
-import java.security.spec.X509EncodedKeySpec
-import java.util.Base64
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtProperties: JwtProperties,
     private val googleOAuth2SuccessHandler: GoogleOAuth2SuccessHandler,
+    private val jwtDecoder: JwtDecoder,
 ) {
 
     @Bean
+    @Order(2)
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
@@ -39,24 +37,7 @@ class SecurityConfig(
                     .anyRequest().authenticated()
             }
             .oauth2Login { it.successHandler(googleOAuth2SuccessHandler) }
-            .oauth2ResourceServer { it.jwt { jwt -> jwt.decoder(jwtDecoder()) } }
+            .oauth2ResourceServer { it.jwt { jwt -> jwt.decoder(jwtDecoder) } }
         return http.build()
-    }
-
-    @Bean
-    fun jwtDecoder(): NimbusJwtDecoder {
-        if (jwtProperties.publicKey.isBlank()) {
-            // Fallback for test environments where JWT_PUBLIC_KEY is not configured
-            return NimbusJwtDecoder.withPublicKey(generateTestKey()).build()
-        }
-        val publicKey = KeyFactory.getInstance("RSA")
-            .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(jwtProperties.publicKey))) as RSAPublicKey
-        return NimbusJwtDecoder.withPublicKey(publicKey).build()
-    }
-
-    private fun generateTestKey(): RSAPublicKey {
-        val kpg = java.security.KeyPairGenerator.getInstance("RSA")
-        kpg.initialize(2048)
-        return kpg.generateKeyPair().public as RSAPublicKey
     }
 }

--- a/src/main/resources/db/migration/V2__oauth2_schema.sql
+++ b/src/main/resources/db/migration/V2__oauth2_schema.sql
@@ -1,0 +1,62 @@
+-- Spring Authorization Server 1.4.x schemas, adapted for PostgreSQL (blob → text)
+
+CREATE TABLE oauth2_registered_client (
+    id                            varchar(100)                        NOT NULL,
+    client_id                     varchar(100)                        NOT NULL,
+    client_id_issued_at           timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret                 varchar(200)                        DEFAULT NULL,
+    client_secret_expires_at      timestamp                           DEFAULT NULL,
+    client_name                   varchar(200)                        NOT NULL,
+    client_authentication_methods varchar(1000)                       NOT NULL,
+    authorization_grant_types     varchar(1000)                       NOT NULL,
+    redirect_uris                 varchar(1000)                       DEFAULT NULL,
+    post_logout_redirect_uris     varchar(1000)                       DEFAULT NULL,
+    scopes                        varchar(1000)                       NOT NULL,
+    client_settings               varchar(2000)                       NOT NULL,
+    token_settings                varchar(2000)                       NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization (
+    id                            varchar(100)  NOT NULL,
+    registered_client_id          varchar(100)  NOT NULL,
+    principal_name                varchar(200)  NOT NULL,
+    authorization_grant_type      varchar(100)  NOT NULL,
+    authorized_scopes             varchar(1000) DEFAULT NULL,
+    attributes                    text          DEFAULT NULL,
+    state                         varchar(500)  DEFAULT NULL,
+    authorization_code_value      text          DEFAULT NULL,
+    authorization_code_issued_at  timestamp     DEFAULT NULL,
+    authorization_code_expires_at timestamp     DEFAULT NULL,
+    authorization_code_metadata   text          DEFAULT NULL,
+    access_token_value            text          DEFAULT NULL,
+    access_token_issued_at        timestamp     DEFAULT NULL,
+    access_token_expires_at       timestamp     DEFAULT NULL,
+    access_token_metadata         text          DEFAULT NULL,
+    access_token_type             varchar(100)  DEFAULT NULL,
+    access_token_scopes           varchar(1000) DEFAULT NULL,
+    oidc_id_token_value           text          DEFAULT NULL,
+    oidc_id_token_issued_at       timestamp     DEFAULT NULL,
+    oidc_id_token_expires_at      timestamp     DEFAULT NULL,
+    oidc_id_token_metadata        text          DEFAULT NULL,
+    refresh_token_value           text          DEFAULT NULL,
+    refresh_token_issued_at       timestamp     DEFAULT NULL,
+    refresh_token_expires_at      timestamp     DEFAULT NULL,
+    refresh_token_metadata        text          DEFAULT NULL,
+    user_code_value               text          DEFAULT NULL,
+    user_code_issued_at           timestamp     DEFAULT NULL,
+    user_code_expires_at          timestamp     DEFAULT NULL,
+    user_code_metadata            text          DEFAULT NULL,
+    device_code_value             text          DEFAULT NULL,
+    device_code_issued_at         timestamp     DEFAULT NULL,
+    device_code_expires_at        timestamp     DEFAULT NULL,
+    device_code_metadata          text          DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization_consent (
+    registered_client_id varchar(100)  NOT NULL,
+    principal_name       varchar(200)  NOT NULL,
+    authorities          varchar(1000) NOT NULL,
+    PRIMARY KEY (registered_client_id, principal_name)
+);

--- a/src/test/kotlin/com/aibles/iam/authorization/infra/authserver/AuthorizationServerConfigTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/infra/authserver/AuthorizationServerConfigTest.kt
@@ -1,0 +1,71 @@
+package com.aibles.iam.authorization.infra.authserver
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.security.KeyPairGenerator
+import java.util.Base64
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthorizationServerConfigTest {
+
+    @Autowired lateinit var mockMvc: MockMvc
+
+    companion object {
+        @Container @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+
+        @Container @JvmStatic
+        val redis: GenericContainer<*> = GenericContainer("redis:7-alpine").withExposedPorts(6379)
+
+        private val keyPair by lazy {
+            KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { redis.host }
+            registry.add("spring.data.redis.port") { redis.getMappedPort(6379).toString() }
+            registry.add("jwt.private-key") { Base64.getEncoder().encodeToString(keyPair.private.encoded) }
+            registry.add("jwt.public-key") { Base64.getEncoder().encodeToString(keyPair.public.encoded) }
+        }
+    }
+
+    @Test
+    fun `OIDC discovery endpoint returns issuer and jwks_uri`() {
+        mockMvc.get("/.well-known/openid-configuration")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.issuer") { exists() }
+                jsonPath("$.jwks_uri") { exists() }
+                jsonPath("$.token_endpoint") { exists() }
+                jsonPath("$.authorization_endpoint") { exists() }
+            }
+    }
+
+    @Test
+    fun `JWK Set endpoint returns RSA key`() {
+        mockMvc.get("/oauth2/jwks")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.keys") { isArray() }
+                jsonPath("$.keys[0].kty") { value("RSA") }
+                jsonPath("$.keys[0].kid") { value("iam-rsa") }
+            }
+    }
+}


### PR DESCRIPTION
Closes #40

## Summary
- Add V2 Flyway migration with Spring Authorization Server JDBC schema (3 tables: `oauth2_registered_client`, `oauth2_authorization`, `oauth2_authorization_consent`)
- Create `AuthorizationServerConfig` with `@Order(HIGHEST_PRECEDENCE)` filter chain, JWK source using key ID `iam-rsa`, JDBC-backed repositories, and OIDC enabled
- Refactor `SecurityConfig` to `@Order(2)`, inject `JwtDecoder` from `AuthorizationServerConfig`, remove local `jwtDecoder()` bean and test-key fallback
- Update `GoogleOAuth2SuccessHandler` to detect OAuth2 AS authorization code flow via `HttpSessionRequestCache` and redirect instead of writing token JSON

## Test plan
- [x] `AuthorizationServerConfigTest` — `/.well-known/openid-configuration` returns issuer, jwks_uri, token_endpoint, authorization_endpoint
- [x] `AuthorizationServerConfigTest` — `/oauth2/jwks` returns RSA key with kid `iam-rsa`
- [x] All existing tests continue to pass (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)