### PR TITLE
fix(authorization): extract shared RSAKey bean, make RequestCache injectable

### DIFF
--- a/src/main/kotlin/com/aibles/iam/authentication/infra/GoogleOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/infra/GoogleOAuth2SuccessHandler.kt
@@ -18,10 +18,9 @@ import org.springframework.stereotype.Component
 class GoogleOAuth2SuccessHandler(
     private val loginWithGoogleUseCase: LoginWithGoogleUseCase,
     private val objectMapper: ObjectMapper,
+    private val requestCache: HttpSessionRequestCache = HttpSessionRequestCache(),
+    private val savedRequestHandler: SavedRequestAwareAuthenticationSuccessHandler = SavedRequestAwareAuthenticationSuccessHandler(),
 ) : AuthenticationSuccessHandler {
-
-    private val requestCache = HttpSessionRequestCache()
-    private val savedRequestHandler = SavedRequestAwareAuthenticationSuccessHandler()
 
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/aibles/iam/authorization/infra/authserver/AuthorizationServerConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/infra/authserver/AuthorizationServerConfig.kt
@@ -56,7 +56,7 @@ class AuthorizationServerConfig(private val jwtProperties: JwtProperties) {
     }
 
     @Bean
-    fun jwkSource(): JWKSource<SecurityContext> {
+    fun rsaKey(): RSAKey {
         val kf = KeyFactory.getInstance("RSA")
         val privateKey = kf.generatePrivate(
             PKCS8EncodedKeySpec(Base64.getDecoder().decode(jwtProperties.privateKey))
@@ -64,9 +64,12 @@ class AuthorizationServerConfig(private val jwtProperties: JwtProperties) {
         val publicKey = kf.generatePublic(
             X509EncodedKeySpec(Base64.getDecoder().decode(jwtProperties.publicKey))
         ) as RSAPublicKey
-        val rsaKey = RSAKey.Builder(publicKey).privateKey(privateKey).keyID("iam-rsa").build()
-        return ImmutableJWKSet(JWKSet(rsaKey))
+        return RSAKey.Builder(publicKey).privateKey(privateKey).keyID("iam-rsa").build()
     }
+
+    @Bean
+    fun jwkSource(rsaKey: RSAKey): JWKSource<SecurityContext> =
+        ImmutableJWKSet(JWKSet(rsaKey))
 
     @Bean
     fun jwtDecoder(jwkSource: JWKSource<SecurityContext>): JwtDecoder =

--- a/src/test/kotlin/com/aibles/iam/authorization/infra/JwtServiceTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/infra/JwtServiceTest.kt
@@ -6,14 +6,16 @@ import com.aibles.iam.shared.error.UnauthorizedException
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
 import java.time.Instant
-import java.util.Base64
 import java.util.Date
 import java.util.UUID
 
@@ -22,12 +24,17 @@ class JwtServiceTest {
     private val keyPair = KeyPairGenerator.getInstance("RSA")
         .apply { initialize(2048) }.generateKeyPair()
 
+    private val rsaKey = RSAKey.Builder(keyPair.public as RSAPublicKey)
+        .privateKey(keyPair.private as RSAPrivateKey)
+        .keyID("test-rsa")
+        .build()
+
     private val props = JwtProperties(
-        privateKey = Base64.getEncoder().encodeToString(keyPair.private.encoded),
-        publicKey = Base64.getEncoder().encodeToString(keyPair.public.encoded),
+        privateKey = "",
+        publicKey = "",
         accessTokenTtlMinutes = 15,
     )
-    private val service = JwtService(props)
+    private val service = JwtService(rsaKey, props)
 
     @Test
     fun `generated token contains correct claims`() {

--- a/src/test/kotlin/com/aibles/iam/authorization/usecase/IssueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/usecase/IssueTokenUseCaseTest.kt
@@ -4,23 +4,29 @@ import com.aibles.iam.authorization.domain.token.TokenStore
 import com.aibles.iam.authorization.infra.JwtService
 import com.aibles.iam.identity.domain.user.User
 import com.aibles.iam.shared.config.JwtProperties
+import com.nimbusds.jose.jwk.RSAKey
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.security.KeyPairGenerator
-import java.util.Base64
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
 
 class IssueTokenUseCaseTest {
 
     private val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+    private val rsaKey = RSAKey.Builder(keyPair.public as RSAPublicKey)
+        .privateKey(keyPair.private as RSAPrivateKey)
+        .keyID("test-rsa")
+        .build()
     private val props = JwtProperties(
-        privateKey = Base64.getEncoder().encodeToString(keyPair.private.encoded),
-        publicKey = Base64.getEncoder().encodeToString(keyPair.public.encoded),
+        privateKey = "",
+        publicKey = "",
         accessTokenTtlMinutes = 15,
     )
-    private val jwtService = JwtService(props)
+    private val jwtService = JwtService(rsaKey, props)
     private val tokenStore = mockk<TokenStore>()
     private val useCase = IssueTokenUseCase(jwtService, tokenStore, props)
 

--- a/src/test/kotlin/com/aibles/iam/authorization/usecase/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/usecase/RefreshTokenUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.aibles.iam.shared.config.JwtProperties
 import com.aibles.iam.shared.error.ErrorCode
 import com.aibles.iam.shared.error.ForbiddenException
 import com.aibles.iam.shared.error.UnauthorizedException
+import com.nimbusds.jose.jwk.RSAKey
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -15,19 +16,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.security.KeyPairGenerator
-import java.util.Base64
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
 
 class RefreshTokenUseCaseTest {
 
     private val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+    private val rsaKey = RSAKey.Builder(keyPair.public as RSAPublicKey)
+        .privateKey(keyPair.private as RSAPrivateKey)
+        .keyID("test-rsa")
+        .build()
     private val props = JwtProperties(
-        privateKey = Base64.getEncoder().encodeToString(keyPair.private.encoded),
-        publicKey = Base64.getEncoder().encodeToString(keyPair.public.encoded),
+        privateKey = "",
+        publicKey = "",
         accessTokenTtlMinutes = 15,
     )
     private val tokenStore = mockk<TokenStore>()
     private val getUserUseCase = mockk<GetUserUseCase>()
-    private val jwtService = JwtService(props)
+    private val jwtService = JwtService(rsaKey, props)
     private val issueToken = IssueTokenUseCase(jwtService, tokenStore, props)
     private val useCase = RefreshTokenUseCase(tokenStore, getUserUseCase, issueToken)
 


### PR DESCRIPTION
Code quality fixes from review of #40.

## Changes

- **DRY: shared RSAKey bean** — `AuthorizationServerConfig` now exposes a `@Bean fun rsaKey(): RSAKey` that parses the RSA key pair once from `JwtProperties`. Both `jwkSource()` and `JwtService` consume this single bean, eliminating the duplicate `KeyFactory` / `Base64` decode code that previously existed in both classes.

- **Constructor-injectable RequestCache** — `GoogleOAuth2SuccessHandler` moves `requestCache` and `savedRequestHandler` from anonymous field initializers to constructor parameters with defaults, making the dependencies visible and injectable in tests.

## Tests

All existing tests updated to pass `RSAKey` directly to `JwtService` constructor (`JwtServiceTest`, `IssueTokenUseCaseTest`, `RefreshTokenUseCaseTest`). Full suite passes.