### PR TITLE
fix(authorization): OAuth2 client seeder test and code cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,5 @@ JWT_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY--
 JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
 APP_BASE_URL=http://localhost:8080
 ALLOWED_ORIGINS=http://localhost:3000
+IAM_WEB_REDIRECT_URI=http://localhost:3000/callback
+IAM_SERVICE_CLIENT_SECRET={noop}changeme

--- a/src/main/kotlin/com/aibles/iam/authorization/infra/authserver/OAuth2ClientSeeder.kt
+++ b/src/main/kotlin/com/aibles/iam/authorization/infra/authserver/OAuth2ClientSeeder.kt
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.core.oidc.OidcScopes
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings
-import org.springframework.security.oauth2.server.authorization.settings.TokenSettings
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -52,7 +51,6 @@ class OAuth2ClientSeeder(
         .scope(OidcScopes.EMAIL)
         .scope(OidcScopes.PROFILE)
         .clientSettings(ClientSettings.builder().requireProofKey(true).build())
-        .tokenSettings(TokenSettings.builder().build())
         .build()
 
     private fun buildIamServiceClient() = RegisteredClient
@@ -64,7 +62,5 @@ class OAuth2ClientSeeder(
         .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
         .scope("iam:read")
         .scope("iam:write")
-        .clientSettings(ClientSettings.builder().build())
-        .tokenSettings(TokenSettings.builder().build())
         .build()
 }

--- a/src/test/kotlin/com/aibles/iam/authorization/infra/authserver/OAuth2ClientSeederTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authorization/infra/authserver/OAuth2ClientSeederTest.kt
@@ -2,7 +2,6 @@ package com.aibles.iam.authorization.infra.authserver
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -32,6 +31,7 @@ class OAuth2ClientSeederTest {
 
         val saved = mutableListOf<RegisteredClient>()
         verify { repository.save(capture(saved)) }
+        assertThat(saved).hasSize(2)  // both iam-web and iam-service must be saved
 
         val iamWeb = saved.find { it.clientId == "iam-web" }
         assertThat(iamWeb).isNotNull()


### PR DESCRIPTION
Code quality fixes from review of #42

- Add `hasSize(2)` assertion in test 1 to confirm both `iam-web` and `iam-service` clients are saved
- Remove unused `import io.mockk.slot` from test file
- Remove no-op `.tokenSettings(TokenSettings.builder().build())` from `buildIamWebClient()`
- Remove no-op `.clientSettings()` and `.tokenSettings()` from `buildIamServiceClient()`
- Remove now-unused `TokenSettings` import from seeder
- Add `IAM_WEB_REDIRECT_URI` and `IAM_SERVICE_CLIENT_SECRET` to `.env.example`