### PR TITLE
fix(security): remove STATELESS session policy from API filter chain

### DIFF
--- a/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/shared/config/SecurityConfig.kt
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.web.SecurityFilterChain
 
@@ -22,7 +21,6 @@ class SecurityConfig(
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers(


### PR DESCRIPTION
## Summary

- Removed `SessionCreationPolicy.STATELESS` from the `@Order(2)` security filter chain
- With STATELESS, `HttpSessionRequestCache.getRequest()` always returned null in `GoogleOAuth2SuccessHandler`, causing the AS authorization-code flow branch to never trigger
- Spring's OAuth2 state CSRF validation was also broken by STATELESS
- The JWT resource server remains stateless at the token level (validates JWTs per-request) regardless of session policy; the session policy only affects whether session state is created/used for the login flow

## Test plan

- [x] All existing tests pass (`./gradlew test`)
- [x] No new code added — 2-line deletion only