### PR TITLE
chore(audit): return metadata as nested JSON object in API response

### DIFF
--- a/src/main/kotlin/com/aibles/iam/audit/api/dto/AuditLogResponse.kt
+++ b/src/main/kotlin/com/aibles/iam/audit/api/dto/AuditLogResponse.kt
@@ -2,6 +2,7 @@ package com.aibles.iam.audit.api.dto
 
 import com.aibles.iam.audit.domain.log.AuditEvent
 import com.aibles.iam.audit.usecase.QueryAuditLogsUseCase
+import com.fasterxml.jackson.annotation.JsonRawValue
 import java.time.Instant
 import java.util.UUID
 
@@ -12,7 +13,7 @@ data class AuditLogResponse(
     val actorId: UUID?,
     val ipAddress: String?,
     val userAgent: String?,
-    val metadata: String?,
+    @JsonRawValue val metadata: String?,
     val createdAt: Instant,
 ) {
     companion object {

--- a/src/test/kotlin/com/aibles/iam/audit/api/AuditLogsControllerTest.kt
+++ b/src/test/kotlin/com/aibles/iam/audit/api/AuditLogsControllerTest.kt
@@ -118,6 +118,37 @@ class AuditLogsControllerTest {
     }
 
     @Test
+    fun `GET audit-logs returns metadata as nested JSON object`() {
+        val logId = UUID.randomUUID()
+        val now = Instant.now()
+
+        every { queryAuditLogsUseCase.execute(any()) } returns PageResponse(
+            content = listOf(
+                QueryAuditLogsUseCase.AuditLogItem(
+                    id = logId,
+                    eventType = AuditEvent.USER_CREATED,
+                    userId = null,
+                    actorId = null,
+                    ipAddress = null,
+                    userAgent = null,
+                    metadata = """{"email":"a@b.com"}""",
+                    createdAt = now,
+                )
+            ),
+            page = 0,
+            size = 20,
+            totalElements = 1,
+            totalPages = 1,
+        )
+
+        mockMvc.get("/api/v1/audit-logs")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.content[0].metadata.email") { value("a@b.com") }
+            }
+    }
+
+    @Test
     fun `GET audit-logs returns empty page when no logs`() {
         every { queryAuditLogsUseCase.execute(any()) } returns PageResponse(
             content = emptyList(),


### PR DESCRIPTION
Closes #66

## Summary
- Add `@JsonRawValue` annotation to `AuditLogResponse.metadata` so JSON metadata strings are serialized as nested objects instead of escaped strings
- Add test verifying metadata is returned as a nested JSON object (asserting `$.data.content[0].metadata.email`)

## Test plan
- [x] Existing audit log controller tests pass
- [x] New test confirms metadata is deserialized as nested JSON