### PR TITLE
feat(docs): add OpenAPI configuration and controller tags

### DIFF
--- a/src/main/kotlin/com/aibles/iam/audit/api/AuditLogsController.kt
+++ b/src/main/kotlin/com/aibles/iam/audit/api/AuditLogsController.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/audit-logs")
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Audit Logs", description = "Query audit trail")
 class AuditLogsController(
     private val queryAuditLogsUseCase: QueryAuditLogsUseCase,
 ) {

--- a/src/main/kotlin/com/aibles/iam/authentication/api/AuthController.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/AuthController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/auth")
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Auth", description = "Token refresh and logout")
 class AuthController(
     private val refreshTokenUseCase: RefreshTokenUseCase,
     private val revokeTokenUseCase: RevokeTokenUseCase,

--- a/src/main/kotlin/com/aibles/iam/authentication/api/PasskeyController.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/api/PasskeyController.kt
@@ -29,6 +29,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/auth/passkey")
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Passkey", description = "WebAuthn passkey registration and authentication")
 class PasskeyController(
     private val registerPasskeyStartUseCase: RegisterPasskeyStartUseCase,
     private val registerPasskeyFinishUseCase: RegisterPasskeyFinishUseCase,

--- a/src/main/kotlin/com/aibles/iam/identity/api/UsersController.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/api/UsersController.kt
@@ -25,6 +25,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/users")
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Users", description = "User lifecycle management")
 class UsersController(
     private val getUserUseCase: GetUserUseCase,
     private val createUserUseCase: CreateUserUseCase,

--- a/src/main/kotlin/com/aibles/iam/shared/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/aibles/iam/shared/config/OpenApiConfig.kt
@@ -1,0 +1,20 @@
+package com.aibles.iam.shared.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI = OpenAPI().info(
+        Info()
+            .title("IAM Service API")
+            .description("Identity & Access Management — Google OAuth2, Passkey/WebAuthn, OAuth2/OIDC SSO, Audit Logging")
+            .version("1.0.0")
+            .contact(Contact().name("Aibles").url("https://aibles.com"))
+    )
+}


### PR DESCRIPTION
Closes #76

## Summary
- Create `OpenApiConfig` bean with API title, description, version, and contact
- Add `@Tag` annotations to all 4 controllers: Users, Auth, Passkey, Audit Logs

## Test plan
- [x] Annotations don't affect test behavior — full suite passes (103 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)