### PR TITLE
test(audit): add audit log query integration test

### DIFF
--- a/src/main/kotlin/com/aibles/iam/audit/domain/log/AuditLog.kt
+++ b/src/main/kotlin/com/aibles/iam/audit/domain/log/AuditLog.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.ColumnTransformer
 import java.time.Instant
 import java.util.UUID
 
@@ -26,12 +27,14 @@ class AuditLog private constructor(
     val actorId: UUID?,
 
     @Column(name = "ip_address", columnDefinition = "inet")
+    @ColumnTransformer(write = "CAST(? AS inet)")
     val ipAddress: String?,
 
     @Column(name = "user_agent")
     val userAgent: String?,
 
     @Column(name = "metadata", columnDefinition = "jsonb")
+    @ColumnTransformer(write = "CAST(? AS jsonb)")
     val metadata: String?,
 
     @Column(name = "created_at", nullable = false)

--- a/src/test/kotlin/com/aibles/iam/BaseIntegrationTest.kt
+++ b/src/test/kotlin/com/aibles/iam/BaseIntegrationTest.kt
@@ -7,27 +7,24 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@Testcontainers
 @ActiveProfiles("integration")
 abstract class BaseIntegrationTest {
 
     companion object {
-        @Container
         @JvmStatic
         val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
             .withDatabaseName("iam_test")
             .withUsername("test")
             .withPassword("test")
+            .apply { start() }
 
-        @Container
         @JvmStatic
         val redis: GenericContainer<*> = GenericContainer("redis:7-alpine")
             .withExposedPorts(6379)
+            .apply { start() }
 
         @DynamicPropertySource
         @JvmStatic

--- a/src/test/kotlin/com/aibles/iam/audit/AuditLogIntegrationTest.kt
+++ b/src/test/kotlin/com/aibles/iam/audit/AuditLogIntegrationTest.kt
@@ -1,0 +1,56 @@
+package com.aibles.iam.audit
+
+import com.aibles.iam.BaseIntegrationTest
+import com.aibles.iam.identity.api.dto.CreateUserRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+class AuditLogIntegrationTest : BaseIntegrationTest() {
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `creating a user produces USER_CREATED audit event`() {
+        val body = objectMapper.writeValueAsString(
+            CreateUserRequest("audit-test@example.com", "Audit Test")
+        )
+
+        // Create a user — this should trigger a USER_CREATED audit event
+        mockMvc.post("/api/v1/users") {
+            with(jwt())
+            contentType = MediaType.APPLICATION_JSON
+            content = body
+        }.andExpect { status { isCreated() } }
+
+        // Query audit logs for USER_CREATED events
+        mockMvc.get("/api/v1/audit-logs") {
+            with(jwt())
+            param("eventType", "USER_CREATED")
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.totalElements", greaterThanOrEqualTo(1))
+            jsonPath("$.data.content[0].eventType") { value("USER_CREATED") }
+        }
+    }
+
+    @Test
+    fun `audit-logs endpoint returns empty page when no events match filter`() {
+        mockMvc.get("/api/v1/audit-logs") {
+            with(jwt())
+            param("eventType", "TOKEN_REVOKED")
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data.totalElements") { value(0) }
+            jsonPath("$.data.content") { isEmpty() }
+        }
+    }
+}


### PR DESCRIPTION
Closes #79

## Summary
- Add `AuditLogIntegrationTest` verifying cross-BC audit event pipeline (create user → USER_CREATED audit event)
- Add empty filter result test (TOKEN_REVOKED returns empty page)
- Fix `AuditLog` entity with `@ColumnTransformer` casts for PostgreSQL `inet` and `jsonb` columns
- Switch `BaseIntegrationTest` to singleton container pattern (containers survive across test classes)

## Test plan
- [x] Audit integration tests verify end-to-end event pipeline
- [x] Full test suite passes (107 tests — 103 unit + 4 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)