### PR TITLE
fix(audit): replace ColumnTransformer casts with proper type mappings

### DIFF
--- a/src/main/kotlin/com/aibles/iam/audit/domain/log/AuditLog.kt
+++ b/src/main/kotlin/com/aibles/iam/audit/domain/log/AuditLog.kt
@@ -6,7 +6,8 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.ColumnTransformer
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.time.Instant
 import java.util.UUID
 
@@ -26,15 +27,14 @@ class AuditLog private constructor(
     @Column(name = "actor_id")
     val actorId: UUID?,
 
-    @Column(name = "ip_address", columnDefinition = "inet")
-    @ColumnTransformer(write = "CAST(? AS inet)")
+    @Column(name = "ip_address")
     val ipAddress: String?,
 
     @Column(name = "user_agent")
     val userAgent: String?,
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "metadata", columnDefinition = "jsonb")
-    @ColumnTransformer(write = "CAST(? AS jsonb)")
     val metadata: String?,
 
     @Column(name = "created_at", nullable = false)

--- a/src/main/resources/db/migration/V4__fix_audit_ip_column_type.sql
+++ b/src/main/resources/db/migration/V4__fix_audit_ip_column_type.sql
@@ -1,0 +1,3 @@
+-- Change ip_address from INET to TEXT.
+-- We store IPs as plain strings in JPA and never use inet operators or range queries.
+ALTER TABLE audit_logs ALTER COLUMN ip_address TYPE TEXT USING ip_address::TEXT;


### PR DESCRIPTION
## Summary
- Migrate `ip_address` column from INET to TEXT via Flyway V4 migration (no inet operators are used)
- Replace `@ColumnTransformer(write = "CAST(? AS jsonb)")` with Hibernate 6 native `@JdbcTypeCode(SqlTypes.JSON)` on metadata field
- Removes runtime CAST overhead on every INSERT and eliminates fragile Hibernate-specific hacks

## Test Plan
- [x] All 107 tests pass including integration tests with Testcontainers PostgreSQL
- [x] Flyway V4 migration applies cleanly on fresh database
- [x] Audit log recording works end-to-end (verified via integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)