### PR TITLE
fix(auth): link googleSub for email-matched users; avoid orphaned tokens on AS redirect

### DIFF
--- a/src/main/kotlin/com/aibles/iam/authentication/infra/GoogleOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/infra/GoogleOAuth2SuccessHandler.kt
@@ -4,6 +4,7 @@ import com.aibles.iam.audit.domain.log.AuditDomainEvent
 import com.aibles.iam.audit.domain.log.AuditEvent
 import com.aibles.iam.authentication.api.dto.TokenResponse
 import com.aibles.iam.authentication.usecase.LoginWithGoogleUseCase
+import com.aibles.iam.authentication.usecase.SyncGoogleUserUseCase
 import com.aibles.iam.shared.response.ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class GoogleOAuth2SuccessHandler(
+    private val syncGoogleUserUseCase: SyncGoogleUserUseCase,
     private val loginWithGoogleUseCase: LoginWithGoogleUseCase,
     private val objectMapper: ObjectMapper,
     private val eventPublisher: ApplicationEventPublisher,
@@ -42,28 +44,32 @@ class GoogleOAuth2SuccessHandler(
             return
         }
 
-        // Ensure user exists in DB for both flows
-        val result = loginWithGoogleUseCase.execute(LoginWithGoogleUseCase.Command(principal))
+        // Check for OAuth2 AS authorization code flow FIRST to avoid issuing tokens that
+        // will be immediately discarded. The AS redirect path only needs the user to exist
+        // in the DB — token issuance is handled by the AS after redirecting back.
+        val savedRequest = requestCache.getRequest(request, response)
+        if (savedRequest != null) {
+            val result = syncGoogleUserUseCase.execute(SyncGoogleUserUseCase.Command(principal))
+            eventPublisher.publishEvent(AuditDomainEvent(
+                eventType = AuditEvent.LOGIN_GOOGLE_SUCCESS,
+                userId = result.user.id,
+                actorId = result.user.id,
+                metadata = mapOf("email" to result.user.email),
+            ))
+            savedRequestHandler.onAuthenticationSuccess(request, response, authentication)
+            return
+        }
 
-        // Note: For first-time users, CreateUserUseCase (called inside LoginWithGoogleUseCase)
-        // also publishes USER_CREATED. So a first login produces two audit events:
-        // USER_CREATED + LOGIN_GOOGLE_SUCCESS. This is intentional — they are distinct operations.
+        // Direct Google login flow: upsert user + issue tokens + return JSON.
+        // Note: first-time users also trigger USER_CREATED (from CreateUserUseCase), so
+        // a first login produces two audit events: USER_CREATED + LOGIN_GOOGLE_SUCCESS.
+        val result = loginWithGoogleUseCase.execute(LoginWithGoogleUseCase.Command(principal))
         eventPublisher.publishEvent(AuditDomainEvent(
             eventType = AuditEvent.LOGIN_GOOGLE_SUCCESS,
             userId = result.user.id,
             actorId = result.user.id,
             metadata = mapOf("email" to result.user.email),
         ))
-
-        // OAuth2 AS authorization code flow: a saved request is in the session.
-        // Redirect back so the AS can issue the authorization code to the client.
-        val savedRequest = requestCache.getRequest(request, response)
-        if (savedRequest != null) {
-            savedRequestHandler.onAuthenticationSuccess(request, response, authentication)
-            return
-        }
-
-        // Direct Google login flow: write token JSON response
         val body = ApiResponse.ok(TokenResponse(result.accessToken, result.refreshToken, result.expiresIn))
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.status = HttpServletResponse.SC_OK

--- a/src/main/kotlin/com/aibles/iam/authentication/usecase/LoginWithGoogleUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/usecase/LoginWithGoogleUseCase.kt
@@ -2,38 +2,19 @@ package com.aibles.iam.authentication.usecase
 
 import com.aibles.iam.authorization.usecase.IssueTokenUseCase
 import com.aibles.iam.identity.domain.user.User
-import com.aibles.iam.identity.domain.user.UserRepository
-import com.aibles.iam.identity.usecase.CreateUserUseCase
-import com.aibles.iam.shared.error.ErrorCode
-import com.aibles.iam.shared.error.ForbiddenException
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.stereotype.Component
 
 @Component
 class LoginWithGoogleUseCase(
-    private val userRepository: UserRepository,
-    private val createUserUseCase: CreateUserUseCase,
+    private val syncGoogleUserUseCase: SyncGoogleUserUseCase,
     private val issueTokenUseCase: IssueTokenUseCase,
 ) {
     data class Command(val oidcUser: OidcUser)
     data class Result(val user: User, val accessToken: String, val refreshToken: String, val expiresIn: Long)
 
     fun execute(command: Command): Result {
-        val oidcUser = command.oidcUser
-        val googleSub = oidcUser.subject
-        val email = oidcUser.email ?: error("Google OIDC user missing email")
-        val name = oidcUser.fullName
-
-        val user = userRepository.findByGoogleSub(googleSub)
-            ?: userRepository.findByEmail(email)
-            ?: createUserUseCase.execute(CreateUserUseCase.Command(email, name, googleSub)).user
-
-        if (!user.isActive())
-            throw ForbiddenException("Account is disabled", ErrorCode.USER_DISABLED)
-
-        user.recordLogin()
-        userRepository.save(user)
-
+        val user = syncGoogleUserUseCase.execute(SyncGoogleUserUseCase.Command(command.oidcUser)).user
         val tokens = issueTokenUseCase.execute(IssueTokenUseCase.Command(user))
         return Result(user, tokens.accessToken, tokens.refreshToken, tokens.expiresIn)
     }

--- a/src/main/kotlin/com/aibles/iam/authentication/usecase/SyncGoogleUserUseCase.kt
+++ b/src/main/kotlin/com/aibles/iam/authentication/usecase/SyncGoogleUserUseCase.kt
@@ -1,0 +1,35 @@
+package com.aibles.iam.authentication.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.ForbiddenException
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.stereotype.Component
+
+@Component
+class SyncGoogleUserUseCase(
+    private val userRepository: UserRepository,
+    private val createUserUseCase: CreateUserUseCase,
+) {
+    data class Command(val oidcUser: OidcUser)
+    data class Result(val user: User)
+
+    fun execute(command: Command): Result {
+        val googleSub = command.oidcUser.subject
+        val email = command.oidcUser.email ?: error("Google OIDC user missing email")
+        val name = command.oidcUser.fullName
+
+        val user = userRepository.findByGoogleSub(googleSub)
+            ?: userRepository.findByEmail(email)?.also { it.linkGoogleAccount(googleSub) }
+            ?: createUserUseCase.execute(CreateUserUseCase.Command(email, name, googleSub)).user
+
+        if (!user.isActive())
+            throw ForbiddenException("Account is disabled", ErrorCode.USER_DISABLED)
+
+        user.recordLogin()
+        userRepository.save(user)
+        return Result(user)
+    }
+}

--- a/src/main/kotlin/com/aibles/iam/identity/domain/user/User.kt
+++ b/src/main/kotlin/com/aibles/iam/identity/domain/user/User.kt
@@ -19,7 +19,7 @@ class User private constructor(
     @Id val id: UUID = UUID.randomUUID(),
     @Column(unique = true, nullable = false) val email: String,
     var displayName: String? = null,
-    @Column(unique = true) val googleSub: String? = null,
+    @Column(unique = true) var googleSub: String? = null,
     @Enumerated(EnumType.STRING) var status: UserStatus = UserStatus.ACTIVE,
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "user_roles", joinColumns = [JoinColumn(name = "user_id")])
@@ -59,6 +59,11 @@ class User private constructor(
 
     fun recordLogin() {
         lastLoginAt = Instant.now()
+        updatedAt = Instant.now()
+    }
+
+    fun linkGoogleAccount(googleSub: String) {
+        this.googleSub = googleSub
         updatedAt = Instant.now()
     }
 

--- a/src/test/kotlin/com/aibles/iam/authentication/usecase/SyncGoogleUserUseCaseTest.kt
+++ b/src/test/kotlin/com/aibles/iam/authentication/usecase/SyncGoogleUserUseCaseTest.kt
@@ -1,0 +1,93 @@
+package com.aibles.iam.authentication.usecase
+
+import com.aibles.iam.identity.domain.user.User
+import com.aibles.iam.identity.domain.user.UserRepository
+import com.aibles.iam.identity.usecase.CreateUserUseCase
+import com.aibles.iam.shared.error.ErrorCode
+import com.aibles.iam.shared.error.ForbiddenException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.oauth2.core.oidc.OidcIdToken
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
+import java.time.Instant
+
+class SyncGoogleUserUseCaseTest {
+
+    private val userRepository = mockk<UserRepository>()
+    private val createUserUseCase = mockk<CreateUserUseCase>()
+    private val useCase = SyncGoogleUserUseCase(userRepository, createUserUseCase)
+
+    private fun oidcUser(sub: String, email: String, name: String? = "Test User"): DefaultOidcUser {
+        val claims = mutableMapOf<String, Any>("sub" to sub, "iss" to "https://accounts.google.com")
+        val idToken = OidcIdToken("token-value", Instant.now(), Instant.now().plusSeconds(3600), claims)
+        val userInfoClaims = mutableMapOf<String, Any>("sub" to sub, "email" to email)
+        if (name != null) userInfoClaims["name"] = name
+        val userInfo = OidcUserInfo(userInfoClaims)
+        return DefaultOidcUser(listOf(OidcUserAuthority(idToken, userInfo)), idToken, userInfo, "sub")
+    }
+
+    @Test
+    fun `new user is created when neither googleSub nor email match`() {
+        val oidcUser = oidcUser("sub-new", "new@example.com")
+        val newUser = User.create("new@example.com", "Test User", "sub-new")
+        every { userRepository.findByGoogleSub("sub-new") } returns null
+        every { userRepository.findByEmail("new@example.com") } returns null
+        every { createUserUseCase.execute(any()) } returns CreateUserUseCase.Result(newUser)
+        every { userRepository.save(newUser) } returns newUser
+
+        val result = useCase.execute(SyncGoogleUserUseCase.Command(oidcUser))
+
+        assertThat(result.user.email).isEqualTo("new@example.com")
+        verify(exactly = 1) { createUserUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `email-matched user gets googleSub linked and saved`() {
+        val oidcUser = oidcUser("sub-link", "preexisting@example.com")
+        val existingUser = User.create("preexisting@example.com", "Pre User")   // googleSub is null
+        assertThat(existingUser.googleSub).isNull()
+
+        every { userRepository.findByGoogleSub("sub-link") } returns null
+        every { userRepository.findByEmail("preexisting@example.com") } returns existingUser
+        val savedSlot = slot<User>()
+        every { userRepository.save(capture(savedSlot)) } returns existingUser
+
+        useCase.execute(SyncGoogleUserUseCase.Command(oidcUser))
+
+        assertThat(savedSlot.captured.googleSub).isEqualTo("sub-link")
+        verify(exactly = 0) { createUserUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `existing user found by googleSub is returned without creating`() {
+        val existingUser = User.create("existing@example.com", "Alice", "sub-existing")
+        val oidcUser = oidcUser("sub-existing", "existing@example.com")
+        every { userRepository.findByGoogleSub("sub-existing") } returns existingUser
+        every { userRepository.save(existingUser) } returns existingUser
+
+        val result = useCase.execute(SyncGoogleUserUseCase.Command(oidcUser))
+
+        assertThat(result.user.email).isEqualTo("existing@example.com")
+        verify(exactly = 0) { createUserUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `disabled user throws ForbiddenException`() {
+        val disabledUser = User.create("disabled@example.com").also { it.disable() }
+        val oidcUser = oidcUser("sub-d", "disabled@example.com")
+        every { userRepository.findByGoogleSub("sub-d") } returns disabledUser
+        every { userRepository.save(disabledUser) } returns disabledUser
+
+        val ex = assertThrows<ForbiddenException> {
+            useCase.execute(SyncGoogleUserUseCase.Command(oidcUser))
+        }
+        assertThat(ex.errorCode).isEqualTo(ErrorCode.USER_DISABLED)
+    }
+}


### PR DESCRIPTION
Closes #89

Changes:
- User.googleSub: val → var, add linkGoogleAccount(sub) domain method
- New SyncGoogleUserUseCase: upsert user + link googleSub + recordLogin (no token issuance)
- LoginWithGoogleUseCase: delegates to SyncGoogleUserUseCase + adds token issuance
- GoogleOAuth2SuccessHandler: checks savedRequest FIRST; AS path uses SyncGoogleUserUseCase (no wasted tokens); direct path uses LoginWithGoogleUseCase
- OidcTokenCustomizer now works correctly for pre-provisioned users (googleSub persisted)